### PR TITLE
portability: overhaul dependency handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,14 @@ DEBUG = 1
 #SRC = $(wildcard src/*.c src/lib/*.c src/ui/*.c)
 SRC = $(wildcard src/*.c src/lib/*.c src/ui/*.c src/gl/*.c src/gl/textures/*.c)
 OBJ = $(SRC:.c=.o)
-CFLAGS = -I ./cglm/include -DRENDER_GL #-DRENDER_SW #-DREVISION_177
-LDFLAGS = -lm -lSDL2 -lSDL2_image -lGLEW -lGL
+CFLAGS += -I ./cglm/include -DRENDER_GL #-DRENDER_SW #-DREVISION_177
+CFLAGS += $(shell sdl2-config --cflags)
+CFLAGS += $(shell pkg-config --cflags SDL2_image)
+CFLAGS += $(shell pkg-config --cflags glew)
+LDFLAGS += -lm
+LDFLAGS += $(shell sdl2-config --libs)
+LDFLAGS += $(shell pkg-config --libs SDL2_image)
+LDFLAGS += $(shell pkg-config --libs glew)
 
 ifdef DEBUG
 CFLAGS += -Wall -Wextra -pedantic -g

--- a/Makefile.windows
+++ b/Makefile.windows
@@ -3,7 +3,7 @@ CC = x86_64-w64-mingw32-gcc
 SRC = $(wildcard src/*.c src/lib/*.c src/ui/*.c)
 OBJ = $(SRC:.c=.o)
 CFLAGS = -I ./cglm/include -I ./glew-2.1.0/include -DRENDER_SW -DREVISION_177
-CFLAGS += -I ./SDL2-2.0.20/x86_64-w64-mingw32/include #-fPIE
+CFLAGS += -I ./SDL2-2.0.20/x86_64-w64-mingw32/include/SDL2 #-fPIE
 LDFLAGS = -lm -L ./SDL2-2.0.20/x86_64-w64-mingw32/lib -lmingw32
 LDFLAGS += -L ./glew-2.1.0/lib/Release/x64/ -lopengl32 -lglu32 -lglew32
 LDFLAGS += -lSDL2main -lSDL2 -lwsock32 -lws2_32 -mwindows

--- a/README.md
+++ b/README.md
@@ -43,10 +43,12 @@ a USB keyboard and mouse can also be used.
 
 ## build (linux)
 
-install [libsdl2-dev](https://packages.debian.org/sid/libsdl2-dev). if compiling
-with opengl support, also install
-[libglew-dev](https://packages.debian.org/sid/libglew-dev) and
-[libgl-dev](https://packages.debian.org/sid/libgl-dev).
+install [libsdl2-dev](https://packages.debian.org/sid/libsdl2-dev).
+if compiling with opengl support, also install
+[libsdl2-image-dev](https://packages.debian.org/sid/libsdl2-image-dev),
+[libglew-dev](https://packages.debian.org/sid/libglew-dev),
+[libgl-dev](https://packages.debian.org/sid/libgl-dev),
+and [pkgconf](https://packages.debian.org/sid/pkgconf).
 
     $ make
     $ ./mudclient

--- a/src/game-model.h
+++ b/src/game-model.h
@@ -36,7 +36,7 @@ typedef struct gl_face_fill {
 #ifdef RENDER_GL
 #include <GL/glew.h>
 #include <GL/glu.h>
-#include <SDL2/SDL_opengl.h>
+#include <SDL_opengl.h>
 
 #ifdef EMSCRIPTEN
 typedef struct gl_pick_vertex {

--- a/src/mudclient.h
+++ b/src/mudclient.h
@@ -59,12 +59,12 @@
 #endif
 
 #if !defined(WII) && !defined(_3DS)
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 #ifdef RENDER_GL
 #include <GL/glew.h>
 #include <GL/glu.h>
-#include <SDL2/SDL_opengl.h>
+#include <SDL_opengl.h>
 
 #include "gl/shader.h"
 #endif

--- a/src/scene.h
+++ b/src/scene.h
@@ -13,7 +13,7 @@
 #ifdef RENDER_GL
 #include <GL/glew.h>
 #include <GL/glu.h>
-#include <SDL2/SDL_opengl.h>
+#include <SDL_opengl.h>
 
 #include "gl/shader.h"
 #endif

--- a/src/utility.h
+++ b/src/utility.h
@@ -24,8 +24,8 @@
 #include <tex3ds.h>
 #endif
 #else
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_image.h>
+#include <SDL.h>
+#include <SDL_image.h>
 
 #ifdef RENDER_GL
 #include <GL/glew.h>

--- a/src/world.h
+++ b/src/world.h
@@ -8,7 +8,7 @@
 #ifdef RENDER_GL
 #include <GL/glew.h>
 #include <GL/glu.h>
-#include <SDL2/SDL_opengl.h>
+#include <SDL_opengl.h>
 
 #define CGLM_DEFINE_PRINTS
 #include <cglm/cglm.h>


### PR DESCRIPTION
use pkg-config to find dependencies on Unix, helps when things are installed outside of core system directories on e.g. BSD/others

note SDL2_image dependency for GL