### PR TITLE
Enable -fwrapv so signed overflow is defined to wrap.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ DEBUG = 1
 #SRC = $(wildcard src/*.c src/lib/*.c src/ui/*.c)
 SRC = $(wildcard src/*.c src/lib/*.c src/ui/*.c src/gl/*.c src/gl/textures/*.c)
 OBJ = $(SRC:.c=.o)
+# remove -fwrapv when code is converted to use unsigned ints or
+# overflow checks are added
+CFLAGS += -fwrapv
 CFLAGS += -I ./cglm/include -DRENDER_GL #-DRENDER_SW #-DREVISION_177
 CFLAGS += $(shell sdl2-config --cflags)
 CFLAGS += $(shell pkg-config --cflags SDL2_image)


### PR DESCRIPTION
There is way too much code that assumes that signed overflow wraps like Java. Many of these data types can eventually be converted to unsigned (or overflow checks added in some cases).

With this change and the `world.c` out of bounds access fixed, the code is clean for`-fsanitize=undefined` when connected to a trustworthy server.  