### PR TITLE
Fix some signed overflow / constness issues in archive decoding

### DIFF
--- a/src/game-model.c
+++ b/src/game-model.c
@@ -63,7 +63,9 @@ void game_model_from7(GameModel *game_model, int vertex_count, int face_count,
     game_model_allocate(game_model, vertex_count, face_count);
 }
 
-void game_model_from_bytes(GameModel *game_model, int8_t *data, int offset) {
+void game_model_from_bytes(GameModel *game_model, int8_t *data) {
+    size_t offset = 0;
+
     game_model_new(game_model);
 
     int vertex_count = get_unsigned_short(data, offset);

--- a/src/game-model.h
+++ b/src/game-model.h
@@ -168,7 +168,7 @@ void game_model_from6(GameModel *game_model, GameModel **pieces, int count,
 void game_model_from7(GameModel *game_model, int vertex_count, int face_count,
                       int autocommit, int isolated, int unlit, int unpickable,
                       int projected);
-void game_model_from_bytes(GameModel *game_model, int8_t *data, int offset);
+void game_model_from_bytes(GameModel *game_model, int8_t *data);
 void game_model_reset(GameModel *game_model);
 void game_model_allocate(GameModel *game_model, int vertex_count,
                          int face_count);

--- a/src/mudclient.c
+++ b/src/mudclient.c
@@ -1911,12 +1911,12 @@ void mudclient_load_models(mudclient *mud) {
         char file_name[strlen(model_name) + 5];
         sprintf(file_name, "%s.ob3", model_name);
 
-        int offset = get_data_file_offset(file_name, models_jag);
+        uint32_t offset = get_data_file_offset(file_name, models_jag);
 
         GameModel *game_model = malloc(sizeof(GameModel));
 
         if (offset != 0) {
-            game_model_from_bytes(game_model, models_jag, offset);
+            game_model_from_bytes(game_model, models_jag + offset);
         } else {
             game_model_from2(game_model, 1, 1);
         }
@@ -1938,14 +1938,14 @@ void mudclient_load_models(mudclient *mud) {
             char file_name[21] = {0};
             sprintf(file_name, "item-%d.ob3", sprite_id);
 
-            int offset = get_data_file_offset(file_name, models_jag);
+            uint32_t offset = get_data_file_offset(file_name, models_jag);
 
             if (offset == 0) {
                 continue;
             }
 
             GameModel *game_model = malloc(sizeof(GameModel));
-            game_model_from_bytes(game_model, models_jag, offset);
+            game_model_from_bytes(game_model, models_jag + offset);
 
             int mask_colour = game_data_item_mask[i];
 
@@ -1976,14 +1976,14 @@ void mudclient_load_models(mudclient *mud) {
             char file_name[21] = {0};
             sprintf(file_name, "item-%d.ob3", i);
 
-            int offset = get_data_file_offset(file_name, models_jag);
+            uint32_t offset = get_data_file_offset(file_name, models_jag);
 
             if (offset == 0) {
                 continue;
             }
 
             GameModel *game_model = malloc(sizeof(GameModel));
-            game_model_from_bytes(game_model, models_jag, offset);
+            game_model_from_bytes(game_model, models_jag + offset);
 
             mud->item_models[i] = game_model;
         }
@@ -5835,13 +5835,13 @@ void mudclient_play_sound(mudclient *mud, char *name) {
     char file_name[strlen(name) + 5];
     sprintf(file_name, "%s.pcm", name);
 
-    int offset = get_data_file_offset(file_name, mud->sound_data);
+    uint32_t offset = get_data_file_offset(file_name, mud->sound_data);
 
     if (offset == 0) {
         return;
     }
 
-    int length = get_data_file_length(file_name, mud->sound_data);
+    uint32_t length = get_data_file_length(file_name, mud->sound_data);
 
     memset(mud->pcm_out, 0, PCM_LENGTH * sizeof(uint16_t));
 

--- a/src/utility.h
+++ b/src/utility.h
@@ -106,9 +106,9 @@ void format_auth_string(char *raw, int max_length, char *formatted);
 void ip_to_string(int32_t ip, char *ip_string);
 int64_t encode_username(char *username);
 void decode_username(int64_t encoded, char *decoded);
-int get_data_file_offset(char *file_name, int8_t *buffer);
-int get_data_file_length(char *file_name, int8_t *buffer);
-int8_t *unpack_data(char *file_name, int extra_size, int8_t *archive_data,
+uint32_t get_data_file_offset(const char *file_name, int8_t *buffer);
+uint32_t get_data_file_length(const char *file_name, int8_t *buffer);
+int8_t *unpack_data(const char *file_name, int extra_size, int8_t *archive_data,
                     int8_t *file_data);
 int8_t *load_data(char *file_name, int extra_size, int8_t *archive_data);
 void format_confirm_amount(int amount, char *formatted);


### PR DESCRIPTION
Fixes a couple of warnings from `-fsanitize=undefiend`. Still too much signed overflow in scene.c/surface.c to be okay without `-fwrapv`.