### PR TITLE
Option to allow holding the mouse button down to buy/sell from shops in bulk

### DIFF
--- a/src/mudclient.c
+++ b/src/mudclient.c
@@ -3425,7 +3425,9 @@ void mudclient_handle_game_input(mudclient *mud) {
         mud->last_mouse_button_down = 0;
     }
 
-    if (mud->show_dialog_trade || mud->show_dialog_duel) {
+    if (mud->show_dialog_trade || mud->show_dialog_duel ||
+        mud->show_dialog_shop) {
+
         if (mud->mouse_button_down != 0) {
             mud->mouse_button_down_time++;
         } else {

--- a/src/mudclient.c
+++ b/src/mudclient.c
@@ -3426,7 +3426,7 @@ void mudclient_handle_game_input(mudclient *mud) {
     }
 
     if (mud->show_dialog_trade || mud->show_dialog_duel ||
-        mud->show_dialog_shop) {
+        (mud->show_dialog_shop && mud->options->hold_to_buy)) {
 
         if (mud->mouse_button_down != 0) {
             mud->mouse_button_down_time++;

--- a/src/options.c
+++ b/src/options.c
@@ -84,6 +84,7 @@ void options_set_defaults(Options *options) {
     options->last_offer_x = 1;
     options->wiki_lookup = 1;
     options->combat_style_always = (MUD_IS_COMPACT ? 0 : 1);
+    options->hold_to_buy = 1;
 
     /* display */
     options->interlace = 0;
@@ -141,6 +142,7 @@ void options_set_vanilla(Options *options) {
     options->last_offer_x = 0;
     options->wiki_lookup = 0;
     options->combat_style_always = 0;
+    options->hold_to_buy = 0;
 
     /* display */
     options->interlace = 0;
@@ -212,6 +214,7 @@ void options_save(Options *options) {
             options->last_offer_x,          //
             options->wiki_lookup,           //
             options->combat_style_always,   //
+            options->hold_to_buy,           //
                                             //
             options->interlace,             //
             options->display_fps,           //
@@ -280,6 +283,7 @@ void options_load(Options *options) {
     OPTION_INI_INT("last_offer_x", options->last_offer_x, 0, 1);
     OPTION_INI_INT("wiki_lookup", options->wiki_lookup, 0, 1);
     OPTION_INI_INT("combat_style_always", options->combat_style_always, 0, 1);
+    OPTION_INI_INT("hold_to_buy", options->hold_to_buy, 0, 1);
 
     /* display */
     OPTION_INI_INT("interlace", options->interlace, 0, 1);

--- a/src/options.h
+++ b/src/options.h
@@ -60,7 +60,9 @@ typedef struct Options Options;
      "; Add RuneScape Wiki lookup button instead of report abuse\n"            \
      "wiki_lookup = %d\n"                                                      \
      "; Combat style menu is usable outside of combat\n"                       \
-     "combat_style_always = %d\n\n"                                            \
+     "combat_style_always = %d\n"                                              \
+     "; Hold to buy/sell items from shops in bulk (matches trade screen)\n"    \
+     "hold_to_buy = %d\n\n"                                                    \
                                                                                \
      "; F1 mode - only render every second scanline\n"                         \
      "interlace = %d\n"                                                        \
@@ -206,6 +208,9 @@ typedef struct Options {
 
     /* combat style menu is usable outside of combat */
     int combat_style_always;
+
+    /* hold to buy/sell items from shops in bulk (matches trade screen) */
+    int hold_to_buy;
 
     /* F1 mode - only render every second scanline */
     int interlace;

--- a/src/ui/additional-options.c
+++ b/src/ui/additional-options.c
@@ -215,6 +215,16 @@ void mudclient_create_options_panel(mudclient *mud) {
     mud->control_options[control] = &mud->options->combat_style_always;
     mud->control_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
+    y += 20;
+
+    control = mudclient_add_option_panel_checkbox(
+        mud->panel_control_options,
+        "@whi@Hold to buy/sell in shop: ",
+        mud->options->hold_to_buy, x, y);
+
+    mud->control_options[control] = &mud->options->hold_to_buy;
+    mud->control_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
+
     /* display */
     x = ui_x + 4;
     y = ui_y + 20 + ADDITIONAL_OPTIONS_TAB_HEIGHT + 4;


### PR DESCRIPTION
Matches the way the authentic trade screen works (and reuses the same code). For protocols before 205, we can't specify a number to sell/buy so this sends one packet per frame. Basically saves fingers when spam clicking and puts the client more on par with ~235 based clients that have "buy/sell X".