### PR TITLE
Fix status bars when current level exceeds base.

### DIFF
--- a/src/surface.c
+++ b/src/surface.c
@@ -3994,7 +3994,8 @@ void surface_draw_scrollbar(Surface *surface, int x, int y, int width,
 void surface_draw_status_bar(Surface *surface, int max, int current,
                              char *label, int x, int y, int width, int height,
                              int background_colour, int foreground_colour) {
-    int current_width = (current / (float)max) * width;
+    int current_width = current >= max ? width :
+                        (current / (float)max) * width;
 
     surface_draw_box_alpha(surface, x, y, current_width, height,
                            foreground_colour, 128);


### PR DESCRIPTION
The bar can exceed the bounds of the box when a player has raised Prayer due to praying at the monastery or using a Potion of Zamorak.

Before:

![2023-10-23-114755_512x346_scrot](https://github.com/2003scape/rsc-c/assets/29542929/af0a0fdc-e69d-4aa8-bcd5-7ab106335c2b)

After:
![2023-10-23-114453_512x346_scrot](https://github.com/2003scape/rsc-c/assets/29542929/8945e4f8-d372-4e4e-9bbf-5467ecc39a71)

(Ignore the right of the image and focus on the left.)

