### PR TITLE
Adjust fog when the client is resized

### DIFF
--- a/src/mudclient.c
+++ b/src/mudclient.c
@@ -4668,7 +4668,7 @@ void mudclient_draw_game(mudclient *mud) {
         mudclient_auto_rotate_camera(mud);
     }
 
-    if (mud->camera_zoom > ZOOM_OUTDOORS) {
+    if (mud->options->zoom_camera) {
         int clip_far =
             (int)((2400.0f / ZOOM_OUTDOORS) * (float)mud->camera_zoom);
 
@@ -4686,6 +4686,20 @@ void mudclient_draw_game(mudclient *mud) {
         mud->scene->clip_far_2d -= 200;
         mud->scene->fog_z_distance -= 200;
     }
+
+    /*
+     * Keep the fog roughly "feeling the same" as the vanilla
+     * 512x346 client when resized beyond that.
+     */
+    if (mud->game_height > MUD_VANILLA_HEIGHT) {
+        int clip_far = mud->scene->clip_far_3d;
+
+        clip_far /= (MUD_VANILLA_HEIGHT / (float)mud->game_height);
+        mud->scene->clip_far_3d = clip_far;
+        mud->scene->clip_far_2d = clip_far;
+        mud->scene->fog_z_distance = clip_far - 100;
+    }
+
 
     int camera_x = mud->camera_auto_rotate_player_x + mud->camera_rotation_x;
     int camera_z = mud->camera_auto_rotate_player_y + mud->camera_rotation_y;

--- a/src/mudclient.h
+++ b/src/mudclient.h
@@ -166,12 +166,15 @@
 
 #define MOUSE_HISTORY_LENGTH 8192
 
+#define MUD_VANILLA_WIDTH 512
+#define MUD_VANILLA_HEIGHT 346
+
 #ifdef _3DS
 #define MUD_WIDTH 320
 #define MUD_HEIGHT 240
 #else
-//#define MUD_WIDTH 512
-//#define MUD_HEIGHT 346
+//#define MUD_WIDTH MUD_VANILLA_WIDTH
+//#define MUD_HEIGHT MUD_VANILLA_HEIGHT
 #define MUD_WIDTH 320
 #define MUD_HEIGHT 240
 #endif


### PR DESCRIPTION
Keeps the amount of fog in the distance at roughly "authentic-feeling" levels.