### PR TITLE
Support OpenGL 1.5 and 2.0

### DIFF
--- a/cache/flat.gl2.fs
+++ b/cache/flat.gl2.fs
@@ -1,0 +1,21 @@
+#version 110
+
+varying vec4 vertex_colour;
+varying vec2 vertex_texture_position;
+varying vec2 vertex_base_texture_position;
+
+uniform sampler2D sprite_texture;
+uniform sampler2D sprite_base_texture;
+
+void main() {
+    vec4 texture_colour = texture2D(sprite_texture, vertex_texture_position);
+
+    vec4 base_texture_colour =
+        texture2D(sprite_base_texture, vertex_base_texture_position);
+
+    gl_FragColor = (texture_colour * vertex_colour) + base_texture_colour;
+
+    if (gl_FragColor.a <= 0.0) {
+        discard;
+    }
+}

--- a/cache/flat.gl2.vs
+++ b/cache/flat.gl2.vs
@@ -1,0 +1,17 @@
+#version 110
+attribute vec3 position;
+attribute vec4 colour;
+attribute vec2 texture_position;
+attribute vec2 base_texture_position;
+
+varying vec4 vertex_colour;
+varying vec2 vertex_texture_position;
+varying vec2 vertex_base_texture_position;
+
+void main() {
+    gl_Position = vec4(position, 1.0);
+
+    vertex_colour = colour;
+    vertex_texture_position = texture_position;
+    vertex_base_texture_position = base_texture_position;
+}

--- a/cache/game-model.gl2.fs
+++ b/cache/game-model.gl2.fs
@@ -1,0 +1,37 @@
+#version 110
+
+#define RAMP_SIZE 256
+
+varying vec3 vertex_colour;
+varying vec2 vertex_texture_position;
+varying float vertex_gradient_index;
+
+uniform sampler2D model_texture;
+
+uniform float light_gradient[RAMP_SIZE];
+uniform float texture_light_gradient[RAMP_SIZE];
+
+uniform float opacity;
+
+void main() {
+    float lightness = 1.0f;
+    int gradient_index = int(vertex_gradient_index);
+
+    vec4 texture_colour = texture2D(model_texture, vertex_texture_position);
+
+    if (texture_colour.w <= 0.0f) {
+        discard;
+    }
+
+    bool is_textured_light =
+        !(texture_colour.r == 1.0 && texture_colour.g == 1.0 &&
+          texture_colour.b == 1.0);
+
+    lightness = is_textured_light ? texture_light_gradient[gradient_index]
+                                  : light_gradient[gradient_index];
+
+    gl_FragColor = vec4(vertex_colour, opacity) * texture_colour;
+
+    gl_FragColor =
+        vec4(vec3(gl_FragColor) * lightness, gl_FragColor.a);
+}

--- a/cache/game-model.gl2.vs
+++ b/cache/game-model.gl2.vs
@@ -1,0 +1,79 @@
+#version 110
+
+#define VERTEX_SCALE 100.0
+
+#define RAMP_SIZE 256.0
+#define USE_GOURAUD 12345678.0
+
+attribute vec3 position;
+attribute vec4 normal;
+attribute vec2 lighting;
+attribute vec3 front_colour;
+attribute vec2 front_texture_position;
+attribute vec3 back_colour;
+attribute vec2 back_texture_position;
+
+varying vec3 vertex_colour;
+varying vec2 vertex_texture_position;
+varying float vertex_gradient_index;
+
+uniform float scroll_texture;
+
+uniform int fog_distance;
+
+uniform mat4 model;
+uniform mat4 projection_view_model;
+
+uniform bool unlit;
+uniform float light_ambience;
+uniform vec3 light_direction;
+uniform float light_diffuse;
+
+uniform bool cull_front;
+
+void main() {
+    gl_Position = projection_view_model * vec4(position, 1.0);
+
+    float face_intensity = lighting.x;
+    float vertex_intensity = lighting.y;
+
+    float intensity = lighting.y;
+    float gradient_index = light_ambience;
+
+    if (unlit) {
+        intensity =
+            face_intensity == USE_GOURAUD ? vertex_intensity : face_intensity;
+    } else {
+        vec3 model_normal = vec3(model * vec4(vec3(normal), 0.0));
+
+        /* normal.w = normal_magnitude */
+        intensity =
+            dot(light_direction, model_normal) / (light_diffuse * normal.w);
+    }
+
+    if (cull_front) {
+        gradient_index += intensity;
+        vertex_colour = back_colour;
+        vertex_texture_position = back_texture_position;
+    } else {
+        gradient_index -= intensity;
+        vertex_colour = front_colour;
+        vertex_texture_position = front_texture_position;
+    }
+
+    // TODO replace division with multiplication
+    if (gl_Position.z > (float(fog_distance) / VERTEX_SCALE)) {
+        gradient_index += gl_Position.z * VERTEX_SCALE - float(fog_distance);
+    }
+
+    gradient_index = max(0.0, min(gradient_index, RAMP_SIZE - 1.0));
+
+    vertex_gradient_index = gradient_index;
+
+    if (vertex_texture_position.x < 0.0) {
+        vertex_texture_position.x *= -1.0;
+        vertex_texture_position.y *= -1.0;
+
+        vertex_texture_position.y += scroll_texture;
+    }
+}

--- a/src/gl/shader.c
+++ b/src/gl/shader.c
@@ -37,6 +37,66 @@ void shader_new(Shader *shader, char *vertex_path, char *fragment_path) {
     const char *vertex_shader_code = buffer_file(vertex_path);
     const char *fragment_shader_code = buffer_file(fragment_path);
 
+    #ifdef OPENGL15
+    GLhandleARB vertex = glCreateShaderObjectARB(GL_VERTEX_SHADER);
+    glShaderSourceARB(vertex, 1, &vertex_shader_code, NULL);
+    glCompileShaderARB(vertex);
+
+    int success = 0;
+
+    glGetObjectParameterfvARB(vertex, GL_COMPILE_STATUS, &success);
+
+    if (!success) {
+        glGetInfoLogARB(vertex, 512, NULL, info_log);
+        fprintf(stderr, "vertex shader error: %s\n", info_log);
+        exit(1);
+    }
+
+    GLhandleARB fragment = glCreateShaderObjectARB(GL_FRAGMENT_SHADER);
+    glShaderSourceARB(fragment, 1, &fragment_shader_code, NULL);
+    glCompileShaderARB(fragment);
+
+    glGetObjectParameterfvARB(fragment, GL_COMPILE_STATUS, &success);
+
+    if (!success) {
+        glGetInfoLogARB(fragment, 512, NULL, info_log);
+        fprintf(stderr, "fragment shader error: %s\n", info_log);
+        exit(1);
+    }
+
+    int id = glCreateProgramObjectARB();
+    glAttachObjectARB(id, vertex);
+    glAttachObjectARB(id, fragment);
+
+    //flats
+    glBindAttribLocationARB(id, 0, "position");
+    glBindAttribLocationARB(id, 1, "colour");
+    glBindAttribLocationARB(id, 2, "texture_position");
+    glBindAttribLocationARB(id, 3, "base_texture_position");
+    //game_models
+    glBindAttribLocationARB(id, 1, "normal");
+    glBindAttribLocationARB(id, 2, "lighting");
+    glBindAttribLocationARB(id, 3, "front_colour");
+    glBindAttribLocationARB(id, 4, "front_texture_position");
+    glBindAttribLocationARB(id, 5, "back_colour");
+    glBindAttribLocationARB(id, 6, "back_texture_position");
+
+    glLinkProgramARB(id);
+
+    glGetObjectParameterfvARB(id, GL_LINK_STATUS, &success);
+
+    if (!success) {
+        glGetInfoLogARB(id, 512, NULL, info_log);
+        fprintf(stderr, "shader link error: %s\n", info_log);
+        exit(1);
+    }
+
+    shader->id = id;
+
+    glDeleteObjectARB(vertex);
+    glDeleteObjectARB(fragment);
+
+    #else //OpenGL2+
     GLuint vertex = glCreateShader(GL_VERTEX_SHADER);
     glShaderSource(vertex, 1, &vertex_shader_code, NULL);
     glCompileShader(vertex);
@@ -66,6 +126,22 @@ void shader_new(Shader *shader, char *vertex_path, char *fragment_path) {
     int id = glCreateProgram();
     glAttachShader(id, vertex);
     glAttachShader(id, fragment);
+
+    #ifdef OPENGL20
+    //flats
+    glBindAttribLocation(id, 0, "position");
+    glBindAttribLocation(id, 1, "colour");
+    glBindAttribLocation(id, 2, "texture_position");
+    glBindAttribLocation(id, 3, "base_texture_position");
+    //game_models
+    glBindAttribLocation(id, 1, "normal");
+    glBindAttribLocation(id, 2, "lighting");
+    glBindAttribLocation(id, 3, "front_colour");
+    glBindAttribLocation(id, 4, "front_texture_position");
+    glBindAttribLocation(id, 5, "back_colour");
+    glBindAttribLocation(id, 6, "back_texture_position");
+    #endif
+
     glLinkProgram(id);
 
     glGetProgramiv(id, GL_LINK_STATUS, &success);
@@ -80,39 +156,73 @@ void shader_new(Shader *shader, char *vertex_path, char *fragment_path) {
 
     glDeleteShader(vertex);
     glDeleteShader(fragment);
+    #endif
 
     free((char *)vertex_shader_code);
     free((char *)fragment_shader_code);
 }
 
-void shader_use(Shader *shader) { glUseProgram(shader->id); }
+void shader_use(Shader *shader) { 
+    #ifdef OPENGL15
+    glUseProgramObjectARB(shader->id);
+    #else
+    glUseProgram(shader->id);
+    #endif
+    }
 
 void shader_set_int(Shader *shader, char *name, int value) {
+    #ifdef OPENGL15
+    glUniform1iARB(glGetUniformLocationARB(shader->id, name), value);
+    #else
     glUniform1i(glGetUniformLocation(shader->id, name), value);
+    #endif
 }
 
 void shader_set_float(Shader *shader, char *name, float value) {
+    #ifdef OPENGL15
+    glUniform1fARB(glGetUniformLocationARB(shader->id, name), value);
+    #else
     glUniform1f(glGetUniformLocation(shader->id, name), value);
+    #endif
 }
 
 void shader_set_float_array(Shader *shader, char *name, float *values,
                             int length) {
+    #ifdef OPENGL15
+    glUniform1fvARB(glGetUniformLocationARB(shader->id, name), length,
+                 (float *)values);
+    #else
     glUniform1fv(glGetUniformLocation(shader->id, name), length,
                  (float *)values);
+    #endif
 }
 
 void shader_set_mat4(Shader *shader, char *name, mat4 value) {
+    #ifdef OPENGL15
+    glUniformMatrix4fvARB(glGetUniformLocationARB(shader->id, name), 1, GL_FALSE,
+                       (float *)value);
+    #else
     glUniformMatrix4fv(glGetUniformLocation(shader->id, name), 1, GL_FALSE,
                        (float *)value);
+    #endif
 }
 
 void shader_set_vec3(Shader *shader, char *name, vec3 value) {
+    #ifdef OPENGL15
+    glUniform3fvARB(glGetUniformLocationARB(shader->id, name), 1, (float *)value);
+    #else
     glUniform3fv(glGetUniformLocation(shader->id, name), 1, (float *)value);
+    #endif
 }
 
 void shader_set_vec3_array(Shader *shader, char *name, vec3 *values,
                            int length) {
+    #ifdef OPENGL15
+    glUniform3fvARB(glGetUniformLocationARB(shader->id, name), length,
+                 (float *)values);
+    #else
     glUniform3fv(glGetUniformLocation(shader->id, name), length,
                  (float *)values);
+    #endif
 }
 #endif

--- a/src/gl/vertex-buffer.c
+++ b/src/gl/vertex-buffer.c
@@ -62,11 +62,21 @@ void vertex_buffer_gl_add_attribute(gl_vertex_buffer *vertex_buffer,
                                     int *attribute_offset,
                                     int attribute_length) {
 #ifdef RENDER_GL
+    #ifdef OPENGL15
+    glVertexAttribPointerARB(vertex_buffer->attribute_index, attribute_length,
+                          GL_FLOAT, GL_FALSE, vertex_buffer->vertex_length,
+                          (void *)((*attribute_offset) * sizeof(GLfloat)));
+    #else
     glVertexAttribPointer(vertex_buffer->attribute_index, attribute_length,
                           GL_FLOAT, GL_FALSE, vertex_buffer->vertex_length,
                           (void *)((*attribute_offset) * sizeof(GLfloat)));
+    #endif
 
+    #ifdef OPENGL15
+    glEnableVertexAttribArrayARB(vertex_buffer->attribute_index);
+    #else
     glEnableVertexAttribArray(vertex_buffer->attribute_index);
+    #endif
 #elif defined(RENDER_3DS_GL)
     AttrInfo_AddLoader(&vertex_buffer->attr_info,
                        vertex_buffer->attribute_index, GPU_FLOAT,

--- a/src/mudclient.c
+++ b/src/mudclient.c
@@ -782,6 +782,18 @@ void mudclient_start_application(mudclient *mud, char *title) {
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
+#elif OPENGL15
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 1);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 5);
+
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK,
+                        SDL_GL_CONTEXT_PROFILE_CORE);
+#elif OPENGL20
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
+
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK,
+                        SDL_GL_CONTEXT_PROFILE_CORE);
 #else
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);

--- a/src/scene.c
+++ b/src/scene.c
@@ -132,6 +132,12 @@ void scene_new(Scene *scene, Surface *surface, int model_count,
 
     shader_new(&scene->game_model_pick_shader, "./cache/pick.webgl.vs",
                "./cache/pick.webgl.fs");
+#elif OPENGL15
+    shader_new(&scene->game_model_shader, "./cache/game-model.gl2.vs",
+               "./cache/game-model.gl2.fs");
+#elif OPENGL20
+    shader_new(&scene->game_model_shader, "./cache/game-model.gl2.vs",
+               "./cache/game-model.gl2.fs");
 #else
     shader_new(&scene->game_model_shader, "./cache/game-model.vs",
                "./cache/game-model.fs");

--- a/src/surface.c
+++ b/src/surface.c
@@ -85,6 +85,10 @@ void surface_new(Surface *surface, int width, int height, int limit,
 #ifdef EMSCRIPTEN
     shader_new(&surface->gl_flat_shader, "./cache/flat.webgl.vs",
                "./cache/flat.webgl.fs");
+#elif OPENGL15
+    shader_new(&surface->gl_flat_shader, "./cache/flat.gl2.vs", "./cache/flat.gl2.fs");
+#elif OPENGL20
+    shader_new(&surface->gl_flat_shader, "./cache/flat.gl2.vs", "./cache/flat.gl2.fs");
 #else
     shader_new(&surface->gl_flat_shader, "./cache/flat.vs", "./cache/flat.fs");
 #endif


### PR DESCRIPTION
Adds more OpenGL rendering options.

OpenGL 1.5 provided the following extensions are available.
GL_ARB_shading_language_100, GL_ARB_vertex_shader, GL_ARB_fragment_shader, GL_ARB_shader_objects.

Used this "OpenGL 1.5 to OpenGL 2.0 GLSL Migration Guide" in reverse as reference.
https://www.yaldex.com/open-gl/app02lev1sec35.html

OpenGL 2.0 only needs core.