### PR TITLE
Install handler to ignore SIGPIPE rather than using send(2)

### DIFF
--- a/src/packet-stream.h
+++ b/src/packet-stream.h
@@ -25,10 +25,6 @@
 #endif
 #endif
 
-#ifndef MSG_NOSIGNAL
-#define MSG_NOSIGNAL 0
-#endif
-
 #ifdef REVISION_177
 #define NO_ISAAC
 #endif
@@ -39,6 +35,11 @@
 
 #ifndef NO_RSA
 #include "lib/bn.h"
+#endif
+
+#if !defined(WIN32) && !defined(WII)
+#define NET_IS_UNIXLIKE
+#define HAVE_SIGNALS
 #endif
 
 #define USERNAME_LENGTH 20


### PR DESCRIPTION
Helps running on platforms that don't have POSIX 2008 and therefore lack send(). Platforms that remain supported that have this restriction include Solaris 10, and probably OpenServer/UnixWare but my VM is currently broken so I can't check. Perhaps more importantly I need this on PowerPC Mac OS X.

Disconnection and reconnection when the server exits function normally.