### PR TITLE
add hover tooltip

### DIFF
--- a/src/mudclient.c
+++ b/src/mudclient.c
@@ -4420,6 +4420,8 @@ void mudclient_draw_ui(mudclient *mud) {
 #endif
             }
         }
+
+        mudclient_draw_hover_tooltip(mud);
     }
 
     if (mud->options->inventory_count) {

--- a/src/options.c
+++ b/src/options.c
@@ -101,6 +101,7 @@ void options_set_defaults(Options *options) {
     options->status_bars = 0;
     options->ground_item_models = 1;
     options->distant_animation = 1;
+    options->show_hover_tooltip = 1;
 
     /* bank */
     options->bank_unstackble_withdraw = 1;
@@ -160,6 +161,7 @@ void options_set_vanilla(Options *options) {
     options->status_bars = 0;
     options->ground_item_models = 0;
     options->distant_animation = 0;
+    options->show_hover_tooltip = 0;
 
     /* bank */
     options->bank_unstackble_withdraw = 0;
@@ -235,6 +237,7 @@ void options_save(Options *options) {
             options->status_bars,           //
             options->ground_item_models,    //
             options->distant_animation,     //
+            options->show_hover_tooltip,    //
                                             //
             options->bank_search,           //
             options->bank_capacity,         //
@@ -307,6 +310,7 @@ void options_load(Options *options) {
     OPTION_INI_INT("status_bars", options->status_bars, 0, 1);
     OPTION_INI_INT("ground_item_models", options->ground_item_models, 0, 1);
     OPTION_INI_INT("distant_animation", options->distant_animation, 0, 1);
+    OPTION_INI_INT("show_hover_tooltip", options->show_hover_tooltip, 0, 1);
 
     /* bank */
     OPTION_INI_INT("bank_search", options->bank_search, 0, 1);

--- a/src/options.h
+++ b/src/options.h
@@ -101,6 +101,8 @@ typedef struct Options Options;
      "ground_item_models = %d\n"                                               \
      "; Always animate objects like fires\n"                                   \
      "distant_animation = %d\n\n"                                              \
+     "; Show hover tooltip menu\n"                                             \
+     "show_hover_tooltip = %d\n"                                               \
                                                                                \
      "; Add filtering to the bank\n"                                           \
      "bank_search = %d\n"                                                      \
@@ -329,6 +331,9 @@ struct Options {
 
     /* experimental thick walls support (requires restart) */
     int thick_walls;
+
+    /* show the current action where the mouse is */
+    int show_hover_tooltip;
 };
 
 void options_new(Options *options);

--- a/src/ui/additional-options.c
+++ b/src/ui/additional-options.c
@@ -227,7 +227,7 @@ void mudclient_create_options_panel(mudclient *mud) {
 
     /* display */
     x = ui_x + 4;
-    y = ui_y + 20 + ADDITIONAL_OPTIONS_TAB_HEIGHT + 4;
+    y = ui_y + 17 + ADDITIONAL_OPTIONS_TAB_HEIGHT + 4;
 
     mud->panel_display_options = malloc(sizeof(Panel));
     panel_new(mud->panel_display_options, mud->surface, 50);
@@ -239,7 +239,7 @@ void mudclient_create_options_panel(mudclient *mud) {
     mud->display_options[control] = &mud->options->interlace;
     mud->display_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += 17;
 
     control = mudclient_add_option_panel_checkbox(
         mud->panel_display_options,
@@ -248,7 +248,7 @@ void mudclient_create_options_panel(mudclient *mud) {
     mud->display_options[control] = &mud->options->display_fps;
     mud->display_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += 17;
 
     control = mudclient_add_option_panel_checkbox(
         mud->panel_display_options, "@whi@UI Scale: ", mud->options->ui_scale,
@@ -257,7 +257,7 @@ void mudclient_create_options_panel(mudclient *mud) {
     mud->display_options[control] = &mud->options->ui_scale;
     mud->display_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += 17;
 
     control = mudclient_add_option_panel_checkbox(
         mud->panel_display_options,
@@ -266,7 +266,7 @@ void mudclient_create_options_panel(mudclient *mud) {
     mud->display_options[control] = &mud->options->anti_alias;
     mud->display_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += 17;
 
     sprintf(formatted_digits, "%d", mud->options->field_of_view);
 
@@ -277,7 +277,7 @@ void mudclient_create_options_panel(mudclient *mud) {
     mud->display_options[control] = &mud->options->field_of_view;
     mud->display_option_types[control] = ADDITIONAL_OPTIONS_INT;
 
-    y += 20;
+    y += 17;
 
     control = mudclient_add_option_panel_checkbox(
         mud->panel_display_options,
@@ -286,7 +286,7 @@ void mudclient_create_options_panel(mudclient *mud) {
     mud->display_options[control] = &mud->options->show_roofs;
     mud->display_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += 17;
 
     control = mudclient_add_option_panel_checkbox(
         mud->panel_display_options,
@@ -295,7 +295,7 @@ void mudclient_create_options_panel(mudclient *mud) {
     mud->display_options[control] = &mud->options->number_commas;
     mud->display_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += 17;
 
     control = mudclient_add_option_panel_checkbox(
         mud->panel_display_options,
@@ -305,7 +305,7 @@ void mudclient_create_options_panel(mudclient *mud) {
     mud->display_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
     x += (ADDITIONAL_OPTIONS_WIDTH - 4) / 2;
-    y = ui_y + 20 + ADDITIONAL_OPTIONS_TAB_HEIGHT + 4;
+    y = ui_y + 17 + ADDITIONAL_OPTIONS_TAB_HEIGHT + 4;
 
     control = mudclient_add_option_panel_checkbox(
         mud->panel_display_options,
@@ -314,7 +314,7 @@ void mudclient_create_options_panel(mudclient *mud) {
     mud->display_options[control] = &mud->options->total_experience;
     mud->display_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += 17;
 
     control = mudclient_add_option_panel_checkbox(
         mud->panel_display_options,
@@ -323,7 +323,7 @@ void mudclient_create_options_panel(mudclient *mud) {
     mud->display_options[control] = &mud->options->experience_drops;
     mud->display_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += 17;
 
     control = mudclient_add_option_panel_checkbox(
         mud->panel_display_options,
@@ -332,7 +332,7 @@ void mudclient_create_options_panel(mudclient *mud) {
     mud->display_options[control] = &mud->options->inventory_count;
     mud->display_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += 17;
 
     control = mudclient_add_option_panel_checkbox(
         mud->panel_display_options,
@@ -341,7 +341,7 @@ void mudclient_create_options_panel(mudclient *mud) {
     mud->display_options[control] = &mud->options->condense_item_amounts;
     mud->display_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += 17;
 
     control = mudclient_add_option_panel_checkbox(
         mud->panel_display_options,
@@ -350,7 +350,7 @@ void mudclient_create_options_panel(mudclient *mud) {
     mud->display_options[control] = &mud->options->certificate_items;
     mud->display_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += 17;
 
     control = mudclient_add_option_panel_checkbox(
         mud->panel_display_options,
@@ -359,7 +359,7 @@ void mudclient_create_options_panel(mudclient *mud) {
     mud->display_options[control] = &mud->options->wilderness_warning;
     mud->display_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += 17;
 
     control = mudclient_add_option_panel_checkbox(
         mud->panel_display_options,
@@ -368,13 +368,22 @@ void mudclient_create_options_panel(mudclient *mud) {
     mud->display_options[control] = &mud->options->status_bars;
     mud->display_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += 17;
 
     control = mudclient_add_option_panel_checkbox(
         mud->panel_display_options,
         "@whi@Ground item models: ", mud->options->ground_item_models, x, y);
 
     mud->display_options[control] = &mud->options->ground_item_models;
+    mud->display_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
+
+    y += 17;
+
+    control = mudclient_add_option_panel_checkbox(
+        mud->panel_display_options,
+        "@whi@Hover Tooltip: ", mud->options->show_hover_tooltip, x, y);
+
+    mud->display_options[control] = &mud->options->show_hover_tooltip;
     mud->display_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
     /* bank */

--- a/src/ui/menu.c
+++ b/src/ui/menu.c
@@ -1463,3 +1463,32 @@ void mudclient_draw_right_click_menu(mudclient *mud) {
                             text_colour);
     }
 }
+
+void mudclient_draw_hover_tooltip(mudclient *mud)
+{
+    if (mud->options->show_hover_tooltip && mud->menu_items_count > 1
+        && mud->mouse_button_down == 0 && mud->show_right_click_menu == 0)
+    {
+        char *menu_item_text1 = mud->menu_item_text1[mud->menu_indices[0]];
+        char *menu_item_text2 = mud->menu_item_text2[mud->menu_indices[0]];
+
+        // if the first menu item equals "Walk here" then we don't want to show
+        // the tooltip
+        if (strcmp(menu_item_text1, "Walk here") == 0) {
+            return;
+        }
+
+        char combined[strlen(menu_item_text1) + strlen(menu_item_text2) + 2];
+        sprintf(combined, "%s %s", menu_item_text1, menu_item_text2);
+
+        int text_width = surface_text_width(combined, FONT_BOLD_12);
+        int text_height = surface_text_height(FONT_BOLD_12);
+
+        surface_draw_box_alpha(mud->surface, mud->mouse_x,
+            mud->mouse_y - text_height, text_width + 5, text_height + 3,
+            GREY_D0, 120);
+
+        surface_draw_string(mud->surface, combined, mud->mouse_x + 2,
+                            mud->mouse_y, FONT_BOLD_12, WHITE);
+    }
+}

--- a/src/ui/menu.h
+++ b/src/ui/menu.h
@@ -81,5 +81,6 @@ void mudclient_menu_add_id_wiki(mudclient *mud, char *display, char *type,
 void mudclient_menu_add_ground_item(mudclient *mud, int index);
 void mudclient_create_right_click_menu(mudclient *mud);
 void mudclient_draw_right_click_menu(mudclient *mud);
+void mudclient_draw_hover_tooltip(mudclient *mud);
 
 #endif


### PR DESCRIPTION
Adds the ability to enable/disable hover tooltips for the current action your move is hovering over. Example image:

https://i.imgur.com/6ZNu6GR.png