### PR TITLE
Support for legacy map file formats

### DIFF
--- a/src/mudclient.c
+++ b/src/mudclient.c
@@ -6861,7 +6861,6 @@ int main(int argc, char **argv) {
     if (argc > 1 && strlen(argv[1]) > 0) {
         mud->options->members = strcmp(argv[1], "members") == 0;
     }
-    mud->options->members = 0;
 
     if (argc > 2) {
         strcpy(mud->options->server, argv[2]);

--- a/src/mudclient.c
+++ b/src/mudclient.c
@@ -1710,29 +1710,29 @@ int8_t *mudclient_read_data_file(mudclient *mud, char *file, char *description,
 
     if (strcmp(file, "jagex.jag") == 0) {
         file_data = (int8_t *)jagex_jag;
-    } else if (strcmp(file, "fonts" FONTS ".jag") == 0) {
+    } else if (strcmp(file, "fonts" VERSION_FONTS_S ".jag") == 0) {
         file_data = (int8_t *)fonts1_jag;
-    } else if (strcmp(file, "config" CONFIG ".jag") == 0) {
+    } else if (strcmp(file, "config" VERSION_CONFIG_S ".jag") == 0) {
         file_data = (int8_t *)config85_jag;
-    } else if (strcmp(file, "media" MEDIA ".jag") == 0) {
+    } else if (strcmp(file, "media" VERSION_MEDIA_S ".jag") == 0) {
         file_data = (int8_t *)media58_jag;
-    } else if (strcmp(file, "entity" ENTITY ".jag") == 0) {
+    } else if (strcmp(file, "entity" VERSION_ENTITY_S ".jag") == 0) {
         file_data = (int8_t *)entity24_jag;
-    } else if (strcmp(file, "entity" ENTITY ".mem") == 0) {
+    } else if (strcmp(file, "entity" VERSION_ENTITY_S ".mem") == 0) {
         file_data = (int8_t *)entity24_mem;
-    } else if (strcmp(file, "textures" TEXTURES ".jag") == 0) {
+    } else if (strcmp(file, "textures" VERSION_TEXTURES_S ".jag") == 0) {
         file_data = (int8_t *)textures17_jag;
-    } else if (strcmp(file, "maps" MAPS ".jag") == 0) {
+    } else if (strcmp(file, "maps" VERSION_MAPS_S ".jag") == 0) {
         file_data = (int8_t *)maps63_jag;
-    } else if (strcmp(file, "maps" MAPS ".mem") == 0) {
+    } else if (strcmp(file, "maps" VERSION_MAPS_S ".mem") == 0) {
         file_data = (int8_t *)maps63_mem;
-    } else if (strcmp(file, "land" MAPS ".jag") == 0) {
+    } else if (strcmp(file, "land" VERSION_MAPS_S ".jag") == 0) {
         file_data = (int8_t *)land63_jag;
-    } else if (strcmp(file, "land" MAPS ".mem") == 0) {
+    } else if (strcmp(file, "land" VERSION_MAPS_S ".mem") == 0) {
         file_data = (int8_t *)land63_mem;
-    } else if (strcmp(file, "models" MODELS ".jag") == 0) {
+    } else if (strcmp(file, "models" VERSION_MODELS_S ".jag") == 0) {
         file_data = (int8_t *)models36_jag;
-    } else if (strcmp(file, "sounds" SOUNDS ".mem") == 0) {
+    } else if (strcmp(file, "sounds" VERSION_SOUNDS_S ".mem") == 0) {
         file_data = (int8_t *)sounds1_mem;
     }
 
@@ -1879,7 +1879,7 @@ void mudclient_load_jagex(mudclient *mud) {
 #endif
 
     int8_t *fonts_jag =
-        mudclient_read_data_file(mud, "fonts" FONTS ".jag", "Game fonts", 5);
+        mudclient_read_data_file(mud, "fonts" VERSION_FONTS_S ".jag", "Game fonts", 5);
 
     if (fonts_jag != NULL) {
         for (int i = 0; i < FONT_FILES_LENGTH; i++) {
@@ -1891,7 +1891,7 @@ void mudclient_load_jagex(mudclient *mud) {
 }
 
 void mudclient_load_game_config(mudclient *mud) {
-    int8_t *config_jag = mudclient_read_data_file(mud, "config" CONFIG ".jag",
+    int8_t *config_jag = mudclient_read_data_file(mud, "config" VERSION_CONFIG_S ".jag",
                                                   "Configuration", 10);
 
     if (config_jag == NULL) {
@@ -1902,7 +1902,7 @@ void mudclient_load_game_config(mudclient *mud) {
     game_data_load_data(config_jag, mud->options->members);
     free(config_jag);
 
-    /*int8_t *filter_jag = mudclient_read_data_file(mud, "filter" FILTER ".jag",
+    /*int8_t *filter_jag = mudclient_read_data_file(mud, "filter" VERSION_FILTER_S ".jag",
                                                   "Chat system", 15);
 
     if (filter_jag == NULL) {
@@ -1916,7 +1916,7 @@ void mudclient_load_game_config(mudclient *mud) {
 void mudclient_load_media(mudclient *mud) {
 #if defined(RENDER_GL) || defined(RENDER_SW) || defined(RENDER_3DS_GL)
     int8_t *media_jag =
-        mudclient_read_data_file(mud, "media" MEDIA ".jag", "2d graphics", 20);
+        mudclient_read_data_file(mud, "media" VERSION_MEDIA_S ".jag", "2d graphics", 20);
 
     if (media_jag == NULL) {
         mud->error_loading_data = 1;
@@ -2026,7 +2026,7 @@ void mudclient_load_media(mudclient *mud) {
 
 void mudclient_load_entities(mudclient *mud) {
 #if defined(RENDER_GL) || defined(RENDER_SW) || defined(RENDER_3DS_GL)
-    int8_t *entity_jag = mudclient_read_data_file(mud, "entity" ENTITY ".jag",
+    int8_t *entity_jag = mudclient_read_data_file(mud, "entity" VERSION_ENTITY_S ".jag",
                                                   "people and monsters", 30);
 
     if (entity_jag == NULL) {
@@ -2039,7 +2039,7 @@ void mudclient_load_entities(mudclient *mud) {
     int8_t *index_dat_mem = NULL;
 
     if (mud->options->members) {
-        entity_jag_mem = mudclient_read_data_file(mud, "entity" ENTITY ".mem",
+        entity_jag_mem = mudclient_read_data_file(mud, "entity" VERSION_ENTITY_S ".mem",
                                                   "member graphics", 45);
 
         if (entity_jag_mem == NULL) {
@@ -2149,7 +2149,7 @@ void mudclient_load_entities(mudclient *mud) {
 void mudclient_load_textures(mudclient *mud) {
 #ifdef RENDER_SW
     int8_t *textures_jag = mudclient_read_data_file(
-        mud, "textures" TEXTURES ".jag", "Textures", 50);
+        mud, "textures" VERSION_TEXTURES_S ".jag", "Textures", 50);
 
     if (textures_jag == NULL) {
         mud->error_loading_data = 1;
@@ -2248,7 +2248,7 @@ void mudclient_load_models(mudclient *mud) {
         game_data_get_model_index(name);
     }
 
-    char *models_filename = "models" MODELS ".jag";
+    char *models_filename = "models" VERSION_MODELS_S ".jag";
 
     int8_t *models_jag =
         mudclient_read_data_file(mud, models_filename, "3d models", 60);
@@ -2379,24 +2379,24 @@ void mudclient_load_models(mudclient *mud) {
 
 void mudclient_load_maps(mudclient *mud) {
     mud->world->map_pack =
-        mudclient_read_data_file(mud, "maps" MAPS ".jag", "map", 70);
+        mudclient_read_data_file(mud, "maps" VERSION_MAPS_S ".jag", "map", 70);
 
     if (mud->options->members) {
         mud->world->member_map_pack = mudclient_read_data_file(
-            mud, "maps" MAPS ".mem", "members map", 75);
+            mud, "maps" VERSION_MAPS_S ".mem", "members map", 75);
     }
 
     mud->world->landscape_pack =
-        mudclient_read_data_file(mud, "land" MAPS ".jag", "landscape", 80);
+        mudclient_read_data_file(mud, "land" VERSION_MAPS_S ".jag", "landscape", 80);
 
     if (mud->options->members) {
         mud->world->member_landscape_pack = mudclient_read_data_file(
-            mud, "land" MAPS ".mem", "members landscape", 85);
+            mud, "land" VERSION_MAPS_S ".mem", "members landscape", 85);
     }
 }
 
 void mudclient_load_sounds(mudclient *mud) {
-    mud->sound_data = mudclient_read_data_file(mud, "sounds" SOUNDS ".mem",
+    mud->sound_data = mudclient_read_data_file(mud, "sounds" VERSION_SOUNDS_S ".mem",
                                                "Sound effects", 90);
 }
 
@@ -6859,6 +6859,7 @@ int main(int argc, char **argv) {
     if (argc > 1 && strlen(argv[1]) > 0) {
         mud->options->members = strcmp(argv[1], "members") == 0;
     }
+    mud->options->members = 0;
 
     if (argc > 2) {
         strcpy(mud->options->server, argv[2]);

--- a/src/mudclient.c
+++ b/src/mudclient.c
@@ -2386,6 +2386,7 @@ void mudclient_load_maps(mudclient *mud) {
             mud, "maps" VERSION_MAPS_S ".mem", "members map", 75);
     }
 
+#if HAS_SEPARATE_LAND
     mud->world->landscape_pack =
         mudclient_read_data_file(mud, "land" VERSION_MAPS_S ".jag", "landscape", 80);
 
@@ -2393,6 +2394,7 @@ void mudclient_load_maps(mudclient *mud) {
         mud->world->member_landscape_pack = mudclient_read_data_file(
             mud, "land" VERSION_MAPS_S ".mem", "members landscape", 85);
     }
+#endif
 }
 
 void mudclient_load_sounds(mudclient *mud) {

--- a/src/version.h
+++ b/src/version.h
@@ -13,8 +13,8 @@
 #define VERSION_FONTS       (1)
 #define VERSION_FONTS_S     "1"
 
-#define VERSION_MAPS        (14)
-#define VERSION_MAPS_S      "14"
+#define VERSION_MAPS        (63)
+#define VERSION_MAPS_S      "63"
 
 #define VERSION_MEDIA       (58)
 #define VERSION_MEDIA_S     "58"

--- a/src/version.h
+++ b/src/version.h
@@ -1,14 +1,31 @@
 #ifndef _H_VERSION
 #define _H_VERSION
 
-#define CONFIG "85"
-#define ENTITY "24"
-#define FILTER "2"
-#define FONTS "1"
-#define MAPS "63"
-#define MEDIA "58"
-#define MODELS "36"
-#define SOUNDS "1"
-#define TEXTURES "17"
+#define VERSION_CONFIG      (85)
+#define VERSION_CONFIG_S    "85"
+
+#define VERSION_ENTITY      (24)
+#define VERSION_ENTITY_S    "24"
+
+#define VERSION_FILTER      (2)
+#define VERSION_FILTER_S    "2"
+
+#define VERSION_FONTS       (1)
+#define VERSION_FONTS_S     "1"
+
+#define VERSION_MAPS        (36)
+#define VERSION_MAPS_S      "36"
+
+#define VERSION_MEDIA       (58)
+#define VERSION_MEDIA_S     "58"
+
+#define VERSION_MODELS      (36)
+#define VERSION_MODELS_S    "36"
+
+#define VERSION_SOUNDS      (1)
+#define VERSION_SOUNDS_S    "1"
+
+#define VERSION_TEXTURES    (17)
+#define VERSION_TEXTURES_S  "17"
 
 #endif

--- a/src/version.h
+++ b/src/version.h
@@ -13,8 +13,8 @@
 #define VERSION_FONTS       (1)
 #define VERSION_FONTS_S     "1"
 
-#define VERSION_MAPS        (36)
-#define VERSION_MAPS_S      "36"
+#define VERSION_MAPS        (14)
+#define VERSION_MAPS_S      "14"
 
 #define VERSION_MEDIA       (58)
 #define VERSION_MEDIA_S     "58"
@@ -27,5 +27,7 @@
 
 #define VERSION_TEXTURES    (17)
 #define VERSION_TEXTURES_S  "17"
+
+#define HAS_SEPARATE_LAND   (VERSION_MAPS > 27)
 
 #endif

--- a/src/world.c
+++ b/src/world.c
@@ -501,8 +501,9 @@ void world_load_section_files(World *world, int x, int y, int plane,
 
 #if VERSION_MAPS > 53
             if (val > 0) {
-                world->walls_diagonal[chunk][tile++] = val + 12000;
+                world->walls_diagonal[chunk][tile] = val + 12000;
             }
+            tile++;
 #else
             if (val < 128) {
                 world->walls_diagonal[chunk][tile++] = val + 12000;

--- a/src/world.c
+++ b/src/world.c
@@ -1,4 +1,5 @@
 #include "world.h"
+#include "version.h"
 
 int terrain_colours[TERRAIN_COLOUR_COUNT];
 
@@ -292,8 +293,10 @@ void world_draw_map_tile(World *world, int x, int y, int direction,
     }
 }
 
-/* TODO rename to read map files? */
-void world_load_section_from4i(World *world, int x, int y, int plane,
+void world_load_section_jm(World *world, int x, int y, int plane, int chunk) {
+}
+
+void world_load_section_files(World *world, int x, int y, int plane,
                                int chunk) {
     if (world->landscape_pack == NULL) {
         return;
@@ -391,27 +394,68 @@ void world_load_section_from4i(World *world, int x, int y, int plane,
     if (map_data != NULL) {
         int offset = 0;
 
-        for (int tile = 0; tile < TILE_COUNT; tile++) {
-            world->walls_north_south[chunk][tile] =
-                get_signed_byte(map_data, offset++, len);
-        }
-
-        for (int tile = 0; tile < TILE_COUNT; tile++) {
-            world->walls_east_west[chunk][tile] =
-                get_signed_byte(map_data, offset++, len);
-        }
-
-        for (int tile = 0; tile < TILE_COUNT; tile++) {
-            world->walls_diagonal[chunk][tile] =
-                get_unsigned_byte(map_data, offset++, len);
-        }
-
-        for (int tile = 0; tile < TILE_COUNT; tile++) {
+        for (int tile = 0; tile < TILE_COUNT;) {
             int val = get_unsigned_byte(map_data, offset++, len);
 
-            if (val > 0) {
-                world->walls_diagonal[chunk][tile] = val + 12000;
+#if VERSION_MAPS > 53
+            world->walls_north_south[chunk][tile++] = val;
+#else
+            if (val < 128) {
+                world->walls_north_south[chunk][tile++] = val;
+            } else {
+                for (int i = 0; i < val - 128; i++) {
+                    world->walls_north_south[chunk][tile++] = 0;
+                }
             }
+#endif
+        }
+
+        for (int tile = 0; tile < TILE_COUNT;) {
+            int val = get_unsigned_byte(map_data, offset++, len);
+
+#if VERSION_MAPS > 53
+            world->walls_east_west[chunk][tile++] = val;
+#else
+            if (val < 128) {
+                world->walls_east_west[chunk][tile++] = val;
+            } else {
+                for (int i = 0; i < val - 128; i++) {
+                    world->walls_east_west[chunk][tile++] = 0;
+                }
+            }
+#endif
+        }
+
+        for (int tile = 0; tile < TILE_COUNT;) {
+            int val = get_unsigned_byte(map_data, offset++, len);
+
+#if VERSION_MAPS > 53
+            world->walls_diagonal[chunk][tile++] = val;
+#else
+            if (val < 128) {
+                world->walls_diagonal[chunk][tile++] = val;
+            } else {
+                for (int i = 0; i < val - 128; i++) {
+                    world->walls_diagonal[chunk][tile++] = 0;
+                }
+            }
+#endif
+        }
+
+        for (int tile = 0; tile < TILE_COUNT;) {
+            int val = get_unsigned_byte(map_data, offset++, len);
+
+#if VERSION_MAPS > 53
+            if (val > 0) {
+                world->walls_diagonal[chunk][tile++] = val + 12000;
+            }
+#else
+            if (val < 128) {
+                world->walls_diagonal[chunk][tile++] = val + 12000;
+            } else {
+                tile += (val - 128);
+            }
+#endif
         }
 
         for (int tile = 0; tile < TILE_COUNT;) {
@@ -844,10 +888,10 @@ void world_load_section_from4(World *world, int x, int y, int plane,
     int section_x = (x + (REGION_SIZE / 2)) / REGION_SIZE;
     int section_y = (y + (REGION_SIZE / 2)) / REGION_SIZE;
 
-    world_load_section_from4i(world, section_x - 1, section_y - 1, plane, 0);
-    world_load_section_from4i(world, section_x, section_y - 1, plane, 1);
-    world_load_section_from4i(world, section_x - 1, section_y, plane, 2);
-    world_load_section_from4i(world, section_x, section_y, plane, 3);
+    world_load_section_files(world, section_x - 1, section_y - 1, plane, 0);
+    world_load_section_files(world, section_x, section_y - 1, plane, 1);
+    world_load_section_files(world, section_x - 1, section_y, plane, 2);
+    world_load_section_files(world, section_x, section_y, plane, 3);
 
     world_set_tiles(world);
 
@@ -2234,12 +2278,12 @@ void world_load_section_from3(World *world, int x, int y, int plane) {
         world_load_section_from4(world, x, y, 1, 0);
         world_load_section_from4(world, x, y, 2, 0);
 
-        world_load_section_from4i(world, section_x - 1, section_y - 1, plane,
+        world_load_section_files(world, section_x - 1, section_y - 1, plane,
                                   0);
 
-        world_load_section_from4i(world, section_x, section_y - 1, plane, 1);
-        world_load_section_from4i(world, section_x - 1, section_y, plane, 2);
-        world_load_section_from4i(world, section_x, section_y, plane, 3);
+        world_load_section_files(world, section_x, section_y - 1, plane, 1);
+        world_load_section_files(world, section_x - 1, section_y, plane, 2);
+        world_load_section_files(world, section_x, section_y, plane, 3);
 
         world_set_tiles(world);
     }

--- a/src/world.h
+++ b/src/world.h
@@ -110,7 +110,7 @@ void world_map_line_vertical(World *world, int x, int y, int height,
                              int colour);
 void world_draw_map_tile(World *world, int i, int j, int k, int l,
                          int texture_id_2);
-void world_load_section_from4i(World *world, int x, int y, int plane,
+void world_load_section_files(World *world, int x, int y, int plane,
                                int chunk);
 void world_method404(World *world, int x, int y, int width, int height);
 int world_get_object_adjacency(World *world, int x, int y);


### PR DESCRIPTION
2001 .jm format maps, here showing Ghost Town:

![2023-12-04-132457_512x346_scrot](https://github.com/2003scape/rsc-c/assets/29542929/e81ee2f0-d71d-406a-89cc-0a88ac204f3c)

2002-2003 mid-format .dats (newly discovered due to this change! Will document shortly).

Showing Varrock before Biohazard.

![2023-12-04-124201_512x346_scrot](https://github.com/2003scape/rsc-c/assets/29542929/9d487b43-0c73-40a9-a38e-5b6d0bab9c80)
