### PR TITLE
Space for more additional options (+more constification)

### DIFF
--- a/src/mudclient.c
+++ b/src/mudclient.c
@@ -911,9 +911,9 @@ void mudclient_resize(mudclient *mud) {
             }
         }
 
-        if (mud->panel_connection_options != NULL) {
-            mud->panel_connection_options->offset_x = half_offset_x;
-            mud->panel_connection_options->offset_y = half_offset_y;
+        if (mud->panel_game_options != NULL) {
+            mud->panel_game_options->offset_x = half_offset_x;
+            mud->panel_game_options->offset_y = half_offset_y;
         }
 
         if (mud->panel_control_options != NULL) {
@@ -921,9 +921,9 @@ void mudclient_resize(mudclient *mud) {
             mud->panel_control_options->offset_y = half_offset_y;
         }
 
-        if (mud->panel_display_options != NULL) {
-            mud->panel_display_options->offset_x = half_offset_x;
-            mud->panel_display_options->offset_y = half_offset_y;
+        if (mud->panel_ui_options != NULL) {
+            mud->panel_ui_options->offset_x = half_offset_x;
+            mud->panel_ui_options->offset_y = half_offset_y;
         }
 
         if (mud->panel_bank_options != NULL) {
@@ -1317,11 +1317,11 @@ void mudclient_key_pressed(mudclient *mud, int code, int char_code) {
         } else if (code == K_F1) {
             mud->options->interlace = !mud->options->interlace;
 
-            for (int i = 0; i < mud->panel_display_options->control_count;
+            for (int i = 0; i < mud->panel_ui_options->control_count;
                  i++) {
-                if ((int *)mud->display_options[i] ==
+                if ((int *)mud->ui_options[i] ==
                     &mud->options->interlace) {
-                    panel_toggle_checkbox(mud->panel_display_options, i,
+                    panel_toggle_checkbox(mud->panel_ui_options, i,
                                           mud->options->interlace);
                     break;
                 }

--- a/src/mudclient.h
+++ b/src/mudclient.h
@@ -1022,17 +1022,17 @@ struct mudclient {
     int show_additional_options;
     int options_tab;
 
-    Panel *panel_connection_options;
-    void *connection_options[50];
-    int connection_option_types[50];
+    Panel *panel_game_options;
+    void *game_options[50];
+    int game_option_types[50];
 
     Panel *panel_control_options;
     void *control_options[50];
     int control_option_types[50];
 
-    Panel *panel_display_options;
-    void *display_options[50];
-    int display_option_types[50];
+    Panel *panel_ui_options;
+    void *ui_options[50];
+    int ui_option_types[50];
 
     Panel *panel_bank_options;
     void *bank_options[50];

--- a/src/options.c
+++ b/src/options.c
@@ -325,7 +325,7 @@ void options_load(Options *options) {
     OPTION_INI_INT("ground_item_models", options->ground_item_models, 0, 1);
     OPTION_INI_INT("ground_item_text", options->ground_item_text, 0, 1);
     OPTION_INI_INT("distant_animation", options->distant_animation, 0, 1);
-    OPTION_INI_INT("tga_sprites", options->tga_sprites, 0, 0);
+    OPTION_INI_INT("tga_sprites", options->tga_sprites, 0, 1);
     OPTION_INI_INT("show_hover_tooltip", options->show_hover_tooltip, 0, 1);
 
     /* bank */

--- a/src/surface.c
+++ b/src/surface.c
@@ -3972,7 +3972,7 @@ int surface_text_width(const char *text, FontStyle font) {
 }
 
 void surface_draw_tabs(Surface *surface, int x, int y, int width, int height,
-                       char **tabs, int tabs_length, int selected) {
+                       const char **tabs, int tabs_length, int selected) {
     int tab_width = (int)(width / (float)tabs_length);
     int offset_x = 0;
 

--- a/src/surface.h
+++ b/src/surface.h
@@ -412,7 +412,7 @@ int surface_text_height_font(FontStyle font);
 int surface_text_height(FontStyle font);
 int surface_text_width(const char *text, FontStyle font);
 void surface_draw_tabs(Surface *surface, int x, int y, int width, int height,
-                       char **tabs, int tabs_length, int selected);
+                       const char **tabs, int tabs_length, int selected);
 void surface_draw_item(Surface *surface, int x, int y, int slot_width,
                        int slot_height, int item_id);
 void surface_draw_item_grid(Surface *surface, int x, int y, int rows,

--- a/src/ui/additional-options.c
+++ b/src/ui/additional-options.c
@@ -1,6 +1,8 @@
 #include "./additional-options.h"
 
-char *option_tabs[] = {"Server", "Controls", "Display", "Bank"};
+#define OPTION_HORIZ_GAP	(18)
+
+const char *option_tabs[] = {"Game", "Controls", "UI", "Bank"};
 
 int mudclient_add_option_panel_label(Panel *panel, char *label, int x, int y) {
     panel_add_text(panel, x, y, label, 1, 0);
@@ -34,100 +36,158 @@ int mudclient_add_option_panel_checkbox(Panel *panel, char *label,
 
 void mudclient_create_options_panel(mudclient *mud) {
     for (int i = 0; i < 50; i++) {
-        mud->connection_option_types[i] = -1;
+        mud->game_option_types[i] = -1;
         mud->control_option_types[i] = -1;
-        mud->display_option_types[i] = -1;
+        mud->ui_option_types[i] = -1;
         mud->bank_option_types[i] = -1;
     }
 
     int ui_x = mud->surface->width / 2 - ADDITIONAL_OPTIONS_WIDTH / 2;
 
-    int ui_y = MUD_IS_COMPACT
-                   ? 4 + (mud->surface->height / 2) - (MUD_HEIGHT / 2)
-                   : mud->surface->height / 2 - ADDITIONAL_OPTIONS_HEIGHT / 2;
+    int ui_y = (mud->surface->height / 2) - ADDITIONAL_OPTIONS_HEIGHT / 2;
 
     int x = ui_x + 4;
-    int y = ui_y + 20 + ADDITIONAL_OPTIONS_TAB_HEIGHT + 4;
+    int y = ui_y + OPTION_HORIZ_GAP + ADDITIONAL_OPTIONS_TAB_HEIGHT + 4;
 
-    /* connection */
-    mud->panel_connection_options = malloc(sizeof(Panel));
-    panel_new(mud->panel_connection_options, mud->surface, 50);
+    /* game */
+    mud->panel_game_options = malloc(sizeof(Panel));
+    panel_new(mud->panel_game_options, mud->surface, 50);
 
     int control = mudclient_add_option_panel_string(
-        mud->panel_connection_options, "@whi@Server: ", mud->options->server,
+        mud->panel_game_options, "@whi@Server: ", mud->options->server,
         255, x, y);
 
-    mud->connection_options[control] = &mud->options->server;
-    mud->connection_option_types[control] = ADDITIONAL_OPTIONS_STRING;
+    mud->game_options[control] = &mud->options->server;
+    mud->game_option_types[control] = ADDITIONAL_OPTIONS_STRING;
 
-    y += 20;
+    y += OPTION_HORIZ_GAP;
 
     char formatted_digits[12] = {0};
     sprintf(formatted_digits, "%d", mud->options->port);
 
-    control = mudclient_add_option_panel_string(mud->panel_connection_options,
+    control = mudclient_add_option_panel_string(mud->panel_game_options,
                                                 "@whi@Port: ", formatted_digits,
                                                 15, x, y);
 
-    mud->connection_options[control] = &mud->options->port;
-    mud->connection_option_types[control] = ADDITIONAL_OPTIONS_INT;
+    mud->game_options[control] = &mud->options->port;
+    mud->game_option_types[control] = ADDITIONAL_OPTIONS_INT;
 
-    y += 20;
+    y += OPTION_HORIZ_GAP;
 
     control = mudclient_add_option_panel_checkbox(
-        mud->panel_connection_options, "@whi@Members: ", mud->options->members,
+        mud->panel_game_options, "@whi@Members: ", mud->options->members,
         x, y);
 
-    mud->connection_options[control] = &mud->options->members;
-    mud->connection_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
+    mud->game_options[control] = &mud->options->members;
+    mud->game_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += OPTION_HORIZ_GAP;
 
     control = mudclient_add_option_panel_checkbox(
-        mud->panel_connection_options,
+        mud->panel_game_options,
         "@whi@Idle logout: ", mud->options->idle_logout, x, y);
 
-    mud->connection_options[control] = &mud->options->idle_logout;
-    mud->connection_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
+    mud->game_options[control] = &mud->options->idle_logout;
+    mud->game_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += OPTION_HORIZ_GAP;
 
     control = mudclient_add_option_panel_checkbox(
-        mud->panel_connection_options,
+        mud->panel_game_options,
         "@whi@Remember username:", mud->options->remember_username, x, y);
 
-    mud->connection_options[control] = &mud->options->remember_username;
-    mud->connection_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
+    mud->game_options[control] = &mud->options->remember_username;
+    mud->game_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += OPTION_HORIZ_GAP;
 
     control = mudclient_add_option_panel_checkbox(
-        mud->panel_connection_options,
+        mud->panel_game_options,
         "@whi@Remember password: ", mud->options->remember_password, x, y);
 
-    mud->connection_options[control] = &mud->options->remember_password;
-    mud->connection_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
+    mud->game_options[control] = &mud->options->remember_password;
+    mud->game_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += OPTION_HORIZ_GAP;
 
     control = mudclient_add_option_panel_checkbox(
-        mud->panel_connection_options,
+        mud->panel_game_options,
         "@whi@Diversify NPCs: ", mud->options->diversify_npcs, x, y);
 
-    mud->connection_options[control] = &mud->options->diversify_npcs;
-    mud->connection_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
+    mud->game_options[control] = &mud->options->diversify_npcs;
+    mud->game_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += OPTION_HORIZ_GAP;
 
     control = mudclient_add_option_panel_checkbox(
-        mud->panel_connection_options,
+        mud->panel_game_options,
+        "@whi@3D ground items: ", mud->options->ground_item_models, x, y);
+
+    mud->game_options[control] = &mud->options->ground_item_models;
+    mud->game_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
+
+    y += OPTION_HORIZ_GAP;
+
+    control = mudclient_add_option_panel_checkbox(
+        mud->panel_game_options,
         "@whi@Rename Herblaw items: ", mud->options->rename_herblaw_items, x, y);
 
-    mud->connection_options[control] = &mud->options->rename_herblaw_items;
-    mud->connection_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
+    mud->game_options[control] = &mud->options->rename_herblaw_items;
+    mud->game_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
+
+    x += (ADDITIONAL_OPTIONS_WIDTH - 4) / 2;
+    y = ui_y + (OPTION_HORIZ_GAP * 3) + ADDITIONAL_OPTIONS_TAB_HEIGHT + 4;
+
+    control = mudclient_add_option_panel_checkbox(
+        mud->panel_game_options,
+        "@whi@Certificate items: ", mud->options->certificate_items, x, y);
+
+    mud->game_options[control] = &mud->options->certificate_items;
+    mud->game_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
+
+    y += OPTION_HORIZ_GAP;
+
+    control = mudclient_add_option_panel_checkbox(
+        mud->panel_game_options,
+        "@whi@Higher quality sprites: ", mud->options->tga_sprites, x, y);
+
+    mud->game_options[control] = &mud->options->tga_sprites;
+    mud->game_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
+
+    y += OPTION_HORIZ_GAP;
+
+    control = mudclient_add_option_panel_checkbox(
+        mud->panel_game_options,
+        "@whi@Show roofs: ", mud->options->show_roofs, x, y);
+
+    mud->game_options[control] = &mud->options->show_roofs;
+    mud->game_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
+
+    y += OPTION_HORIZ_GAP;
+
+    control = mudclient_add_option_panel_checkbox(
+        mud->panel_game_options,
+        "@whi@Interlace (F1): ", mud->options->interlace, x, y);
+
+    mud->game_options[control] = &mud->options->interlace;
+    mud->game_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
+
+    y += OPTION_HORIZ_GAP;
+
+    sprintf(formatted_digits, "%d", mud->options->field_of_view);
+
+    control = mudclient_add_option_panel_string(
+        mud->panel_game_options, "@whi@Field of view: ", formatted_digits, 3,
+        x, y);
+
+    mud->game_options[control] = &mud->options->field_of_view;
+    mud->game_option_types[control] = ADDITIONAL_OPTIONS_INT;
+
+    y += OPTION_HORIZ_GAP;
 
     /* controls */
-    y = ui_y + 20 + ADDITIONAL_OPTIONS_TAB_HEIGHT + 4;
+    x = ui_x + 4;
+    y = ui_y + OPTION_HORIZ_GAP + ADDITIONAL_OPTIONS_TAB_HEIGHT + 4;
 
     mud->panel_control_options = malloc(sizeof(Panel));
     panel_new(mud->panel_control_options, mud->surface, 50);
@@ -139,7 +199,7 @@ void mudclient_create_options_panel(mudclient *mud) {
     mud->control_options[control] = &mud->options->mouse_wheel;
     mud->control_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += OPTION_HORIZ_GAP;
 
     control = mudclient_add_option_panel_checkbox(
         mud->panel_control_options,
@@ -148,7 +208,7 @@ void mudclient_create_options_panel(mudclient *mud) {
     mud->control_options[control] = &mud->options->middle_click_camera;
     mud->control_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += OPTION_HORIZ_GAP;
 
     control = mudclient_add_option_panel_checkbox(
         mud->panel_control_options,
@@ -157,7 +217,7 @@ void mudclient_create_options_panel(mudclient *mud) {
     mud->control_options[control] = &mud->options->zoom_camera;
     mud->control_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += OPTION_HORIZ_GAP;
 
     control = mudclient_add_option_panel_checkbox(
         mud->panel_control_options,
@@ -166,7 +226,7 @@ void mudclient_create_options_panel(mudclient *mud) {
     mud->control_options[control] = &mud->options->tab_respond;
     mud->control_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += OPTION_HORIZ_GAP;
 
     control = mudclient_add_option_panel_checkbox(
         mud->panel_control_options,
@@ -175,7 +235,7 @@ void mudclient_create_options_panel(mudclient *mud) {
     mud->control_options[control] = &mud->options->option_numbers;
     mud->control_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += OPTION_HORIZ_GAP;
 
     control = mudclient_add_option_panel_checkbox(
         mud->panel_control_options,
@@ -184,7 +244,7 @@ void mudclient_create_options_panel(mudclient *mud) {
     mud->control_options[control] = &mud->options->compass_menu;
     mud->control_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += OPTION_HORIZ_GAP;
 
     control = mudclient_add_option_panel_checkbox(
         mud->panel_control_options,
@@ -193,7 +253,7 @@ void mudclient_create_options_panel(mudclient *mud) {
     mud->control_options[control] = &mud->options->transaction_menus;
     mud->control_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += OPTION_HORIZ_GAP;
 
     control = mudclient_add_option_panel_checkbox(
         mud->panel_control_options, "@whi@Offer-X: ", mud->options->offer_x, x,
@@ -202,8 +262,7 @@ void mudclient_create_options_panel(mudclient *mud) {
     mud->control_options[control] = &mud->options->offer_x;
     mud->control_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    x += (ADDITIONAL_OPTIONS_WIDTH - 4) / 2;
-    y = ui_y + 20 + ADDITIONAL_OPTIONS_TAB_HEIGHT + 4;
+    y += OPTION_HORIZ_GAP;
 
     control = mudclient_add_option_panel_checkbox(
         mud->panel_control_options,
@@ -212,25 +271,8 @@ void mudclient_create_options_panel(mudclient *mud) {
     mud->control_options[control] = &mud->options->last_offer_x;
     mud->control_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
-
-    control = mudclient_add_option_panel_checkbox(
-        mud->panel_control_options,
-        "@whi@Wiki lookup: ", mud->options->wiki_lookup, x, y);
-
-    mud->control_options[control] = &mud->options->wiki_lookup;
-    mud->control_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
-
-    y += 20;
-
-    control = mudclient_add_option_panel_checkbox(
-        mud->panel_control_options,
-        "@whi@Style outside combat: ", mud->options->combat_style_always, x, y);
-
-    mud->control_options[control] = &mud->options->combat_style_always;
-    mud->control_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
-
-    y += 20;
+    x += (ADDITIONAL_OPTIONS_WIDTH - 4) / 2;
+    y = ui_y + OPTION_HORIZ_GAP + ADDITIONAL_OPTIONS_TAB_HEIGHT + 4;
 
     control = mudclient_add_option_panel_checkbox(
         mud->panel_control_options,
@@ -239,170 +281,152 @@ void mudclient_create_options_panel(mudclient *mud) {
     mud->control_options[control] = &mud->options->hold_to_buy;
     mud->control_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    /* display */
+    /* ui */
     x = ui_x + 4;
-    y = ui_y + 20 + ADDITIONAL_OPTIONS_TAB_HEIGHT + 4;
+    y = ui_y + OPTION_HORIZ_GAP + ADDITIONAL_OPTIONS_TAB_HEIGHT + 4;
 
-    mud->panel_display_options = malloc(sizeof(Panel));
-    panel_new(mud->panel_display_options, mud->surface, 50);
-
-    control = mudclient_add_option_panel_checkbox(
-        mud->panel_display_options,
-        "@whi@Interlace (F1): ", mud->options->interlace, x, y);
-
-    mud->display_options[control] = &mud->options->interlace;
-    mud->display_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
-
-    y += 20;
+    mud->panel_ui_options = malloc(sizeof(Panel));
+    panel_new(mud->panel_ui_options, mud->surface, 50);
 
     control = mudclient_add_option_panel_checkbox(
-        mud->panel_display_options,
+        mud->panel_ui_options,
         "@whi@Display FPS: ", mud->options->display_fps, x, y);
 
-    mud->display_options[control] = &mud->options->display_fps;
-    mud->display_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
+    mud->ui_options[control] = &mud->options->display_fps;
+    mud->ui_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += OPTION_HORIZ_GAP;
 
     control = mudclient_add_option_panel_checkbox(
-        mud->panel_display_options, "@whi@UI Scale: ", mud->options->ui_scale,
+        mud->panel_ui_options, "@whi@UI Scale: ", mud->options->ui_scale,
         x, y);
 
-    mud->display_options[control] = &mud->options->ui_scale;
-    mud->display_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
+    mud->ui_options[control] = &mud->options->ui_scale;
+    mud->ui_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += OPTION_HORIZ_GAP;
 
     control = mudclient_add_option_panel_checkbox(
-        mud->panel_display_options,
+        mud->panel_ui_options,
         "@whi@Anti-alias: ", mud->options->anti_alias, x, y);
 
-    mud->display_options[control] = &mud->options->anti_alias;
-    mud->display_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
+    mud->ui_options[control] = &mud->options->anti_alias;
+    mud->ui_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
-
-    sprintf(formatted_digits, "%d", mud->options->field_of_view);
-
-    control = mudclient_add_option_panel_string(
-        mud->panel_display_options, "@whi@Field of view: ", formatted_digits, 3,
-        x, y);
-
-    mud->display_options[control] = &mud->options->field_of_view;
-    mud->display_option_types[control] = ADDITIONAL_OPTIONS_INT;
-
-    y += 20;
+    y += OPTION_HORIZ_GAP;
 
     control = mudclient_add_option_panel_checkbox(
-        mud->panel_display_options,
-        "@whi@Show roofs: ", mud->options->show_roofs, x, y);
-
-    mud->display_options[control] = &mud->options->show_roofs;
-    mud->display_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
-
-    y += 20;
-
-    control = mudclient_add_option_panel_checkbox(
-        mud->panel_display_options,
+        mud->panel_ui_options,
         "@whi@Number commas: ", mud->options->number_commas, x, y);
 
-    mud->display_options[control] = &mud->options->number_commas;
-    mud->display_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
+    mud->ui_options[control] = &mud->options->number_commas;
+    mud->ui_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += OPTION_HORIZ_GAP;
 
     control = mudclient_add_option_panel_checkbox(
-        mud->panel_display_options,
+        mud->panel_ui_options,
         "@whi@Remaining XP: ", mud->options->remaining_experience, x, y);
 
-    mud->display_options[control] = &mud->options->remaining_experience;
-    mud->display_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
+    mud->ui_options[control] = &mud->options->remaining_experience;
+    mud->ui_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    x += (ADDITIONAL_OPTIONS_WIDTH - 4) / 2;
-    y = ui_y + 20 + ADDITIONAL_OPTIONS_TAB_HEIGHT + 4;
+    y += OPTION_HORIZ_GAP;
 
     control = mudclient_add_option_panel_checkbox(
-        mud->panel_display_options,
+        mud->panel_ui_options,
         "@whi@Total XP: ", mud->options->total_experience, x, y);
 
-    mud->display_options[control] = &mud->options->total_experience;
-    mud->display_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
+    mud->ui_options[control] = &mud->options->total_experience;
+    mud->ui_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += OPTION_HORIZ_GAP;
 
     control = mudclient_add_option_panel_checkbox(
-        mud->panel_display_options,
+        mud->panel_ui_options,
         "@whi@XP drops: ", mud->options->experience_drops, x, y);
 
-    mud->display_options[control] = &mud->options->experience_drops;
-    mud->display_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
+    mud->ui_options[control] = &mud->options->experience_drops;
+    mud->ui_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += OPTION_HORIZ_GAP;
 
     control = mudclient_add_option_panel_checkbox(
-        mud->panel_display_options,
+        mud->panel_ui_options,
         "@whi@Inventory count: ", mud->options->inventory_count, x, y);
 
-    mud->display_options[control] = &mud->options->inventory_count;
-    mud->display_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
+    mud->ui_options[control] = &mud->options->inventory_count;
+    mud->ui_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += OPTION_HORIZ_GAP;
 
     control = mudclient_add_option_panel_checkbox(
-        mud->panel_display_options,
+        mud->panel_ui_options,
         "@whi@K/M amounts: ", mud->options->condense_item_amounts, x, y);
 
-    mud->display_options[control] = &mud->options->condense_item_amounts;
-    mud->display_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
+    mud->ui_options[control] = &mud->options->condense_item_amounts;
+    mud->ui_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += OPTION_HORIZ_GAP;
 
-    control = mudclient_add_option_panel_checkbox(
-        mud->panel_display_options,
-        "@whi@Certificate items: ", mud->options->certificate_items, x, y);
-
-    mud->display_options[control] = &mud->options->certificate_items;
-    mud->display_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
-
-    y += 20;
+    x += (ADDITIONAL_OPTIONS_WIDTH - 4) / 2;
+    y = ui_y + OPTION_HORIZ_GAP + ADDITIONAL_OPTIONS_TAB_HEIGHT + 4;
 
     control = mudclient_add_option_panel_checkbox(
-        mud->panel_display_options,
+        mud->panel_ui_options,
         "@whi@Wilderness warning: ", mud->options->wilderness_warning, x, y);
 
-    mud->display_options[control] = &mud->options->wilderness_warning;
-    mud->display_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
+    mud->ui_options[control] = &mud->options->wilderness_warning;
+    mud->ui_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += OPTION_HORIZ_GAP;
 
     control = mudclient_add_option_panel_checkbox(
-        mud->panel_display_options,
+        mud->panel_ui_options,
         "@whi@Status bars: ", mud->options->status_bars, x, y);
 
-    mud->display_options[control] = &mud->options->status_bars;
-    mud->display_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
+    mud->ui_options[control] = &mud->options->status_bars;
+    mud->ui_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += OPTION_HORIZ_GAP;
 
     control = mudclient_add_option_panel_checkbox(
-        mud->panel_display_options,
-        "@whi@Ground item models: ", mud->options->ground_item_models, x, y);
+        mud->panel_ui_options,
+        "@whi@Ground item highlight: ", mud->options->ground_item_text, x, y);
 
-    mud->display_options[control] = &mud->options->ground_item_models;
-    mud->display_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
+    mud->ui_options[control] = &mud->options->ground_item_text;
+    mud->ui_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += OPTION_HORIZ_GAP;
 
-    /*control = mudclient_add_option_panel_checkbox(
-        mud->panel_display_options,
+    control = mudclient_add_option_panel_checkbox(
+        mud->panel_ui_options,
         "@whi@Hover tooltip: ", mud->options->show_hover_tooltip, x, y);
 
-    mud->display_options[control] = &mud->options->show_hover_tooltip;
-    mud->display_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;*/
+    mud->ui_options[control] = &mud->options->show_hover_tooltip;
+    mud->ui_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
+
+    y += OPTION_HORIZ_GAP;
+
+    control = mudclient_add_option_panel_checkbox(
+        mud->panel_ui_options,
+        "@whi@Wiki lookup: ", mud->options->wiki_lookup, x, y);
+
+    mud->ui_options[control] = &mud->options->wiki_lookup;
+    mud->ui_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
+
+    y += OPTION_HORIZ_GAP;
+
+    control = mudclient_add_option_panel_checkbox(
+        mud->panel_ui_options,
+        "@whi@Style outside combat: ", mud->options->combat_style_always, x, y);
+
+    mud->ui_options[control] = &mud->options->combat_style_always;
+    mud->ui_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
     /* bank */
     x = ui_x + 4;
-    y = ui_y + 20 + ADDITIONAL_OPTIONS_TAB_HEIGHT + 4;
+    y = ui_y + OPTION_HORIZ_GAP + ADDITIONAL_OPTIONS_TAB_HEIGHT + 4;
 
     mud->panel_bank_options = malloc(sizeof(Panel));
     panel_new(mud->panel_bank_options, mud->surface, 50);
@@ -415,7 +439,7 @@ void mudclient_create_options_panel(mudclient *mud) {
     mud->bank_options[control] = &mud->options->bank_unstackble_withdraw;
     mud->bank_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += OPTION_HORIZ_GAP;
 
     control = mudclient_add_option_panel_checkbox(
         mud->panel_bank_options,
@@ -424,7 +448,7 @@ void mudclient_create_options_panel(mudclient *mud) {
     mud->bank_options[control] = &mud->options->bank_search;
     mud->bank_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += OPTION_HORIZ_GAP;
 
     control = mudclient_add_option_panel_checkbox(
         mud->panel_bank_options,
@@ -433,7 +457,7 @@ void mudclient_create_options_panel(mudclient *mud) {
     mud->bank_options[control] = &mud->options->bank_capacity;
     mud->bank_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += OPTION_HORIZ_GAP;
 
     control = mudclient_add_option_panel_checkbox(
         mud->panel_bank_options,
@@ -442,7 +466,7 @@ void mudclient_create_options_panel(mudclient *mud) {
     mud->bank_options[control] = &mud->options->bank_value;
     mud->bank_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += OPTION_HORIZ_GAP;
 
     control = mudclient_add_option_panel_checkbox(
         mud->panel_bank_options,
@@ -451,7 +475,7 @@ void mudclient_create_options_panel(mudclient *mud) {
     mud->bank_options[control] = &mud->options->bank_deposit_all;
     mud->bank_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += OPTION_HORIZ_GAP;
 
     control = mudclient_add_option_panel_checkbox(
         mud->panel_bank_options,
@@ -460,7 +484,7 @@ void mudclient_create_options_panel(mudclient *mud) {
     mud->bank_options[control] = &mud->options->bank_expand;
     mud->bank_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += OPTION_HORIZ_GAP;
 
     control = mudclient_add_option_panel_checkbox(
         mud->panel_bank_options,
@@ -469,7 +493,7 @@ void mudclient_create_options_panel(mudclient *mud) {
     mud->bank_options[control] = &mud->options->bank_scroll;
     mud->bank_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    y += OPTION_HORIZ_GAP;
 
     control = mudclient_add_option_panel_checkbox(
         mud->panel_bank_options, "@whi@Bank menus: ", mud->options->bank_menus,
@@ -478,8 +502,7 @@ void mudclient_create_options_panel(mudclient *mud) {
     mud->bank_options[control] = &mud->options->bank_menus;
     mud->bank_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    x += (ADDITIONAL_OPTIONS_WIDTH - 4) / 2;
-    y = ui_y + 20 + ADDITIONAL_OPTIONS_TAB_HEIGHT + 4;
+    y += OPTION_HORIZ_GAP;
 
     control = mudclient_add_option_panel_checkbox(
         mud->panel_bank_options,
@@ -488,7 +511,8 @@ void mudclient_create_options_panel(mudclient *mud) {
     mud->bank_options[control] = &mud->options->bank_inventory;
     mud->bank_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += 20;
+    x += (ADDITIONAL_OPTIONS_WIDTH - 4) / 2;
+    y = ui_y + OPTION_HORIZ_GAP + ADDITIONAL_OPTIONS_TAB_HEIGHT + 4;
 
     control = mudclient_add_option_panel_checkbox(
         mud->panel_bank_options,
@@ -502,11 +526,11 @@ Panel *mudclient_get_active_option_panel(mudclient *mud) {
     Panel *panel = NULL;
 
     if (mud->options_tab == ADDITIONAL_OPTIONS_CONNECTION) {
-        panel = mud->panel_connection_options;
+        panel = mud->panel_game_options;
     } else if (mud->options_tab == ADDITIONAL_OPTIONS_CONTROL) {
         panel = mud->panel_control_options;
     } else if (mud->options_tab == ADDITIONAL_OPTIONS_DISPLAY) {
-        panel = mud->panel_display_options;
+        panel = mud->panel_ui_options;
     } else if (mud->options_tab == ADDITIONAL_OPTIONS_BANK) {
         panel = mud->panel_bank_options;
     }
@@ -517,14 +541,14 @@ Panel *mudclient_get_active_option_panel(mudclient *mud) {
 void mudclient_get_active_options(mudclient *mud, void ***options,
                                   int **option_types) {
     if (mud->options_tab == ADDITIONAL_OPTIONS_CONNECTION) {
-        *options = mud->connection_options;
-        *option_types = mud->connection_option_types;
+        *options = mud->game_options;
+        *option_types = mud->game_option_types;
     } else if (mud->options_tab == ADDITIONAL_OPTIONS_CONTROL) {
         *options = mud->control_options;
         *option_types = mud->control_option_types;
     } else if (mud->options_tab == ADDITIONAL_OPTIONS_DISPLAY) {
-        *options = mud->display_options;
-        *option_types = mud->display_option_types;
+        *options = mud->ui_options;
+        *option_types = mud->ui_option_types;
     } else if (mud->options_tab == ADDITIONAL_OPTIONS_BANK) {
         *options = mud->bank_options;
         *option_types = mud->bank_option_types;
@@ -550,17 +574,17 @@ void mudclient_sync_options_panel(Panel *panel, void **options,
 }
 
 void mudclient_sync_options_panels(mudclient *mud) {
-    mudclient_sync_options_panel(mud->panel_connection_options,
-                                 mud->connection_options,
-                                 mud->connection_option_types);
+    mudclient_sync_options_panel(mud->panel_game_options,
+                                 mud->game_options,
+                                 mud->game_option_types);
 
     mudclient_sync_options_panel(mud->panel_control_options,
                                  mud->control_options,
                                  mud->control_option_types);
 
-    mudclient_sync_options_panel(mud->panel_display_options,
-                                 mud->display_options,
-                                 mud->display_option_types);
+    mudclient_sync_options_panel(mud->panel_ui_options,
+                                 mud->ui_options,
+                                 mud->ui_option_types);
 
     mudclient_sync_options_panel(mud->panel_bank_options, mud->bank_options,
                                  mud->bank_option_types);
@@ -571,9 +595,7 @@ void mudclient_draw_additional_options(mudclient *mud) {
 
     int ui_x = mud->surface->width / 2 - ADDITIONAL_OPTIONS_WIDTH / 2;
 
-    int ui_y = MUD_IS_COMPACT
-                   ? 4 + (mud->surface->height / 2) - (MUD_HEIGHT / 2)
-                   : mud->surface->height / 2 - ADDITIONAL_OPTIONS_HEIGHT / 2;
+    int ui_y = mud->surface->height / 2 - ADDITIONAL_OPTIONS_HEIGHT / 2;
 
     surface_draw_box(mud->surface, ui_x, ui_y, ADDITIONAL_OPTIONS_WIDTH, 12,
                      TITLE_BAR_COLOUR);
@@ -649,10 +671,7 @@ void mudclient_draw_additional_options(mudclient *mud) {
 
 void mudclient_handle_additional_options_input(mudclient *mud) {
     int ui_x = mud->surface->width / 2 - ADDITIONAL_OPTIONS_WIDTH / 2;
-
-    int ui_y = MUD_IS_COMPACT
-                   ? 4 + (mud->surface->height / 2) - (MUD_HEIGHT / 2)
-                   : mud->surface->height / 2 - ADDITIONAL_OPTIONS_HEIGHT / 2;
+    int ui_y = mud->surface->height / 2 - ADDITIONAL_OPTIONS_HEIGHT / 2;
 
     /* tabs */
     if (mud->last_mouse_button_down == 1 && mud->mouse_x >= ui_x &&

--- a/src/ui/additional-options.h
+++ b/src/ui/additional-options.h
@@ -4,7 +4,7 @@
 #include "../mudclient.h"
 
 #define ADDITIONAL_OPTIONS_WIDTH 320
-#define ADDITIONAL_OPTIONS_HEIGHT 218
+#define ADDITIONAL_OPTIONS_HEIGHT 224
 
 /* tabs */
 #define ADDITIONAL_OPTIONS_TAB_HEIGHT 24
@@ -19,7 +19,7 @@
 #define ADDITIONAL_OPTIONS_INT 1
 #define ADDITIONAL_OPTIONS_CHECKBOX 2
 
-extern char *option_tabs[];
+extern const char *option_tabs[];
 
 int mudclient_add_option_panel_label(Panel *panel, char *label, int x, int y);
 int mudclient_add_option_panel_string(Panel *panel, char *label,

--- a/src/ui/experience-drops.c
+++ b/src/ui/experience-drops.c
@@ -32,7 +32,7 @@ void mudclient_draw_experience_drops(mudclient *mud) {
         char formatted_amount[15] = {0};
         mudclient_format_number_commas(mud, experience, formatted_amount);
 
-        char *skill_name = skill_names[mud->experience_drop_skill[i]];
+        const char *skill_name = skill_names[mud->experience_drop_skill[i]];
 
         size_t n = strlen(skill_name) + strlen(formatted_amount) +
                    strlen(formatted_remainder);

--- a/src/ui/magic-tab.c
+++ b/src/ui/magic-tab.c
@@ -1,6 +1,6 @@
 #include "magic-tab.h"
 
-char *magic_tabs[] = {"Magic", "Prayers"};
+static const char *magic_tabs[] = {"Magic", "Prayers"};
 
 void mudclient_draw_ui_tab_magic(mudclient *mud, int no_menus) {
     int ui_x = mud->surface->width - MAGIC_WIDTH - 3;

--- a/src/ui/magic-tab.h
+++ b/src/ui/magic-tab.h
@@ -7,8 +7,6 @@
 #define MAGIC_WIDTH 196
 #define MAGIC_TAB_HEIGHT 24
 
-extern char *magic_tabs[];
-
 void mudclient_draw_ui_tab_magic(mudclient *mudclient, int no_menus);
 
 #endif

--- a/src/ui/menu.c
+++ b/src/ui/menu.c
@@ -692,7 +692,8 @@ void mudclient_create_top_mouse_menu(mudclient *mud) {
     }
 }
 
-void mudclient_menu_add_wiki(mudclient *mud, char *display, char *page) {
+void mudclient_menu_add_wiki(mudclient *mud, const char *display,
+                             const char *page) {
     if (!mud->options->wiki_lookup) {
         return;
     }
@@ -704,9 +705,9 @@ void mudclient_menu_add_wiki(mudclient *mud, char *display, char *page) {
     mud->menu_items_count++;
 }
 
-void mudclient_menu_add_id_wiki(mudclient *mud, char *display, char *type,
-                                int id) {
-    char *name = display;
+void mudclient_menu_add_id_wiki(mudclient *mud, const char *display,
+                                const char *type, int id) {
+    const char *name = display;
 
     for (int i = strlen(name); i >= 0; i--) {
         if (name[i] == '@') {

--- a/src/ui/menu.h
+++ b/src/ui/menu.h
@@ -77,9 +77,10 @@ typedef enum {
 
 void mudclient_menu_item_click(mudclient *mud, int i);
 void mudclient_create_top_mouse_menu(mudclient *mud);
-void mudclient_menu_add_wiki(mudclient *mud, char *display, char *page);
-void mudclient_menu_add_id_wiki(mudclient *mud, char *display, char *type,
-                                int id);
+void mudclient_menu_add_wiki(mudclient *mud, const char *display,
+                             const char *page);
+void mudclient_menu_add_id_wiki(mudclient *mud, const char *display,
+                                const char *type, int id);
 void mudclient_menu_add_ground_item(mudclient *mud, int index);
 void mudclient_create_right_click_menu(mudclient *mud);
 void mudclient_draw_right_click_menu(mudclient *mud);

--- a/src/ui/social-tab.c
+++ b/src/ui/social-tab.c
@@ -1,6 +1,6 @@
 #include "social-tab.h"
 
-char *social_tabs[] = {"Friends", "Ignore"};
+static const char *social_tabs[] = {"Friends", "Ignore"};
 
 void mudclient_sort_friends(mudclient *mud) {
     int flag = 1;

--- a/src/ui/social-tab.h
+++ b/src/ui/social-tab.h
@@ -32,8 +32,6 @@ typedef enum {
 #define FRIEND_ONLINE 255
 #endif
 
-extern char *social_tabs[];
-
 void mudclient_sort_friends(mudclient *mud);
 void mudclient_add_friend(mudclient *mud, char *username);
 void mudclient_remove_friend(mudclient *mud, int64_t encoded_username);

--- a/src/ui/stats-tab.c
+++ b/src/ui/stats-tab.c
@@ -1,23 +1,23 @@
 #include "stats-tab.h"
 
-char *short_skill_names[] = {
+static const char *short_skill_names[] = {
     "Attack",   "Defense",  "Strength", "Hits",      "Ranged",  "Prayer",
     "Magic",    "Cooking",  "Woodcut",  "Fletching", "Fishing", "Firemaking",
     "Crafting", "Smithing", "Mining",   "Herblaw",   "Agility", "Thieving"};
 
-char *skill_names[] = {
+const char *skill_names[] = {
     "Attack",   "Defense",  "Strength",    "Hits",      "Ranged",  "Prayer",
     "Magic",    "Cooking",  "Woodcutting", "Fletching", "Fishing", "Firemaking",
     "Crafting", "Smithing", "Mining",      "Herblaw",   "Agility", "Thieving"};
 
 int skills_length;
 
-char *equipment_stat_names[] = {"Armour", "WeaponAim", "WeaponPower", "Magic",
-                                "Prayer"};
+static const char *equipment_stat_names[] = {
+    "Armour", "WeaponAim", "WeaponPower", "Magic", "Prayer"};
 
-int experience_array[100];
+static int experience_array[100];
 
-char *free_quests[] = {
+static const char *free_quests[] = {
     "Black knight's fortress", "Cook's assistant",   "Demon slayer",
     "Doric's quest",           "The restless ghost", "Goblin diplomacy",
     "Ernest the chicken",      "Imp catcher",        "Pirate's treasure",
@@ -25,7 +25,7 @@ char *free_quests[] = {
     "Shield of Arrav",         "The knight's sword", "Vampire slayer",
     "Witch's potion",          "Dragon slayer"};
 
-char *members_quests[] = {
+static const char *members_quests[] = {
     "Witch's house",    "Lost city",         "Hero's quest",
     "Druidic ritual",   "Merlin's crystal",  "Scorpion catcher",
     "Family crest",     "Tribal totem",      "Fishing contest",
@@ -40,8 +40,6 @@ char *members_quests[] = {
 
 char **quest_names;
 int quests_length = 0;
-
-char *stats_tabs[3] = {0};
 
 void init_stats_tab_global() {
     skills_length = sizeof(skill_names) / sizeof(skill_names[0]);
@@ -137,6 +135,8 @@ void mudclient_draw_ui_tab_stats(mudclient *mud, int no_menus) {
 
     int is_compact =
         is_touch || mud->surface->height < (height + STATS_LINE_BREAK) + ui_y;
+
+    const char *stats_tabs[3];
 
     if (is_compact) {
         height = STATS_COMPACT_HEIGHT;
@@ -390,7 +390,7 @@ void mudclient_draw_ui_tab_stats(mudclient *mud, int no_menus) {
             }
 
             if (no_menus && mud->selected_wiki) {
-                char *skill_name = skill_names[selected_skill];
+                const char *skill_name = skill_names[selected_skill];
                 mudclient_menu_add_wiki(mud, skill_name, skill_name);
             }
         } else {
@@ -544,7 +544,7 @@ void mudclient_draw_ui_tab_stats(mudclient *mud, int no_menus) {
             }
 
             if (mud->selected_wiki) {
-                char *wiki_page = stats_tabs[selected_tab];
+                const char *wiki_page = stats_tabs[selected_tab];
 
                 if (is_compact && selected_tab == 1) {
                     wiki_page = "Equipment";

--- a/src/ui/stats-tab.h
+++ b/src/ui/stats-tab.h
@@ -1,6 +1,12 @@
 #ifndef _H_STATS_TAB
 #define _H_STATS_TAB
 
+extern const char *skill_names[];
+extern int skills_length;
+
+extern char **quest_names;
+extern int quests_length;
+
 #include "../mudclient.h"
 
 #define STATS_WIDTH 196
@@ -8,19 +14,6 @@
 #define STATS_COMPACT_HEIGHT 171
 #define STATS_TAB_HEIGHT 24
 #define STATS_LINE_BREAK (MUD_IS_COMPACT ? 11 : 12)
-
-extern char *short_skill_names[];
-extern char *skill_names[];
-extern int skills_length;
-extern char *equipment_stat_names[];
-extern int experience_array[100];
-
-extern char *free_quests[];
-extern char *members_quests[];
-extern char **quest_names;
-extern int quests_length;
-
-extern char *stats_tabs[];
 
 void init_stats_tab_global();
 

--- a/src/ui/transaction.c
+++ b/src/ui/transaction.c
@@ -527,7 +527,7 @@ void mudclient_draw_transaction(mudclient *mud, int dialog_x, int dialog_y,
                         dialog_y + 10, 1, WHITE);
 
     if (MUD_IS_COMPACT) {
-        char *tabs[] = {"Yours", "Theirs"};
+        const char *tabs[] = {"Yours", "Theirs"};
         int tabs_x = dialog_x + TRANSACTION_OFFER_X;
         int tabs_y = dialog_y + TRANSACTION_INVENTORY_Y;
 
@@ -736,7 +736,7 @@ void mudclient_draw_transaction_confirm(mudclient *mud, int dialog_x,
     int y = 30;
 
     if (MUD_IS_COMPACT) {
-        char *tabs[3] = {0};
+        const char *tabs[3] = {0};
 
         if (is_trade) {
             tabs[0] = "Your Offer";

--- a/src/utility.c
+++ b/src/utility.c
@@ -687,7 +687,7 @@ void format_amount_suffix(int amount, int use_colour, int convert_ten_thousands,
     sprintf(dest, "%s%s%c", use_colour ? colour : "", formatted_amount, suffix);
 }
 
-void url_encode(char *s, char *dest) {
+void url_encode(const char *s, char *dest) {
     const char *hex = "0123456789abcdef";
 
     int pos = 0;

--- a/src/utility.h
+++ b/src/utility.h
@@ -124,7 +124,7 @@ void ulaw_to_linear(long size, uint8_t *u_ptr, int16_t *out_ptr);
 void format_number_commas(int number, char *dest);
 void format_amount_suffix(int amount, int use_colour, int convert_ten_thousands,
                           int use_commas, char *dest);
-void url_encode(char *s, char *dest);
+void url_encode(const char *s, char *dest);
 int get_certificate_item_id(int item_id);
 int is_ip_address(char *address);
 int colour_str_to_colour(char *colour_str);


### PR DESCRIPTION
- Simplifies the mobile code since no more custom calculations are needed for the additional options UI.
- "Server" tab renamed to "game", has more options that affect custom content and fundamentals.
- "Display" tab renamed to "UI".
- Text made slightly more compact.
- Height increased (still fits 3DS).
- Add missing options to the menu, fix TGA sprites option to work as expected (valid range should not be 0, 0)

![2024-01-02-105420_512x346_scrot](https://github.com/2003scape/rsc-c/assets/29542929/39256e4c-576e-4bff-ab0a-81e3796b2866)
![2024-01-02-105423_512x346_scrot](https://github.com/2003scape/rsc-c/assets/29542929/d5c377aa-4773-430e-9a58-07f5450f15e7)
![2024-01-02-105427_512x346_scrot](https://github.com/2003scape/rsc-c/assets/29542929/2d7a5d10-8eb3-425a-a7cb-91aa0be760bf)
![2024-01-02-105429_512x346_scrot](https://github.com/2003scape/rsc-c/assets/29542929/af793c5a-df28-4ec5-a688-ecad6bc4c001)
