### PR TITLE
world: Refactor, rename unrenamed functions, resolve various TODOs.

### DIFF
--- a/src/mudclient.c
+++ b/src/mudclient.c
@@ -3426,7 +3426,7 @@ int mudclient_load_next_region(mudclient *mud, int lx, int ly) {
     mud->local_upper_x = section_x * REGION_SIZE + 32;
     mud->local_upper_y = section_y * REGION_SIZE + 32;
 
-    world_load_section_from3(mud->world, lx, ly, mud->last_plane_index);
+    world_load_section(mud->world, lx, ly, mud->last_plane_index);
 
     mud->region_x -= mud->plane_width;
     mud->region_y -= mud->plane_height;
@@ -3466,7 +3466,7 @@ int mudclient_load_next_region(mudclient *mud, int lx, int ly) {
                              -world_get_elevation(mud->world, base_x, base_y),
                              base_y);
 
-            world_remove_object2(mud->world, object_x, object_y, object_id);
+            world_register_object(mud->world, object_x, object_y, object_id);
 
             if (object_id == WINDMILL_SAILS_ID) {
                 game_model_translate(game_model, 0, -480, 0);
@@ -3487,9 +3487,9 @@ int mudclient_load_next_region(mudclient *mud, int lx, int ly) {
         int wall_object_id = mud->wall_objects[i].id;
         int wall_object_dir = mud->wall_objects[i].direction;
 
-        world_set_object_adjacency_from4(mud->world, wall_object_x,
-                                         wall_object_y, wall_object_dir,
-                                         wall_object_id);
+        world_register_wall_object(mud->world, wall_object_x,
+                                   wall_object_y, wall_object_dir,
+                                   wall_object_id);
 
         game_model_destroy(mud->wall_objects[i].model);
         free(mud->wall_objects[i].model);

--- a/src/packet-handler.c
+++ b/src/packet-handler.c
@@ -645,7 +645,7 @@ void mudclient_packet_tick(mudclient *mud) {
 
                     game_model_set_light_from6(model, 1, 48, 48, -50, -10, -50);
 
-                    world_remove_object2(mud->world, area_x, area_y, object_id);
+                    world_register_object(mud->world, area_x, area_y, object_id);
 
                     if (object_id == WINDMILL_SAILS_ID) {
                         game_model_translate(model, 0, -480, 0);
@@ -1109,8 +1109,8 @@ void mudclient_packet_tick(mudclient *mud) {
                         return;
                     }
 
-                    world_set_object_adjacency_from4(mud->world, l_x, l_y,
-                                                     direction, id);
+                    world_register_wall_object(mud->world, l_x, l_y,
+                                               direction, id);
 
                     GameModel *model = mudclient_create_wall_object(
                         mud, l_x, l_y, direction, id, mud->wall_object_count);

--- a/src/ui/login.c
+++ b/src/ui/login.c
@@ -448,8 +448,8 @@ void mudclient_render_login_scene_sprites(mudclient *mud) {
     int region_x = 50; // 49;
     int region_y = 50; // 47;
 
-    world_load_section_from3(mud->world, region_x * 48 + 23, region_y * 48 + 23,
-                             plane);
+    world_load_section(mud->world, region_x * 48 + 23, region_y * 48 + 23,
+                       plane);
 
     world_add_models(mud->world, mud->game_models);
 

--- a/src/world.h
+++ b/src/world.h
@@ -105,63 +105,26 @@ struct World {
     int8_t thick_walls;
 };
 
-void world_new(World *world, Scene *scene, Surface *surface);
-int get_byte_plane_coord(int8_t plane_array[PLANE_COUNT][TILE_COUNT], int x,
-                         int y);
-int get_int_plane_coord(int plane_array[PLANE_COUNT][TILE_COUNT], int x, int y);
-int world_get_wall_east_west(World *world, int x, int y);
-void world_set_terrain_ambience(World *world, int terrain_x, int terrain_y,
-                                int vertex_x, int vertex_y, int ambience);
-int world_get_wall_roof(World *world, int x, int y);
-int world_get_elevation(World *world, int x, int y);
-int world_get_wall_diagonal(World *world, int x, int y);
-void world_remove_object2(World *world, int x, int y, int id);
-void world_remove_wall_object(World *world, int x, int y, int k, int id);
-void world_map_set_pixel(World *world, int x, int y, int colour);
-void world_map_line_horizontal(World *world, int x, int y, int width,
-                               int colour);
-void world_map_line_vertical(World *world, int x, int y, int height,
-                             int colour);
-void world_draw_map_tile(World *world, int i, int j, int k, int l,
-                         int texture_id_2);
-void world_load_section_files(World *world, int x, int y, int plane,
-                               int chunk);
-void world_method404(World *world, int x, int y, int width, int height);
-int world_get_object_adjacency(World *world, int x, int y);
-int world_has_roof(World *world, int x, int y);
-void world_method407(World *world, int i, int j, int k);
-int world_get_terrain_colour(World *world, int x, int y);
-void world_reset(World *world, int dispose);
-void world_set_tiles(World *world);
-int world_get_wall_north_south(World *world, int x, int y);
-int world_get_tile_direction(World *world, int x, int y);
-int world_get_tile_decoration(World *world, int x, int y);
-int world_get_tile_decoration_from4(World *world, int x, int y, int colour);
-void world_set_tile_decoration(World *world, int x, int y, int decoration);
-int world_route(World *world, int start_x, int start_y, int end_x1, int end_y1,
-                int end_x2, int end_y2, int *route_x, int *route_y,
-                int objects);
-void world_set_object_adjacency_from4(World *world, int x, int y, int dir,
-                                      int id);
-void world_load_section_from4(World *world, int x, int y, int plane,
-                              int is_current_plane);
-void world_set_object_adjacency_from3(World *world, int i, int j, int k);
-int world_get_tile_type(World *world, int i, int j);
-void world_add_models(World *world, GameModel **models);
-void world_create_wall(World *world, GameModel *game_model, int wall_object_id,
-                       int x1, int y1, int x2, int y2);
-int world_get_terrain_height(World *world, int x, int y);
-void world_load_section_from3(World *world, int x, int y, int plane);
-void world_method425(World *world, int i, int j, int k);
-void world_remove_object(World *world, int x, int y, int id);
-int world_has_neighbouring_roof(World *world, int x, int y);
-void world_raise_wall_object(World *world, int wall_object_id, int x1, int y1,
-                             int x2, int y2);
-int world_is_under_roof(World *world, int x, int y);
-
 #if defined(RENDER_GL) || defined(RENDER_3DS_GL)
 void world_gl_create_world_models_buffer(World *world, int max_models);
 void world_gl_buffer_world_models(World *world);
 void world_gl_update_terrain_buffers(World *world);
 #endif
+
+void world_new(World *world, Scene *scene, Surface *surface);
+void world_load_section(World *world, int x, int y, int plane);
+int world_route(World *world, int start_x, int start_y, int end_x1, int end_y1,
+                int end_x2, int end_y2, int *route_x, int *route_y,
+                int objects);
+int world_is_under_roof(World *world, int x, int y);
+int world_get_tile_direction(World *world, int x, int y);
+int world_get_elevation(World *world, int x, int y);
+int world_get_wall_roof(World *world, int x, int y);
+void world_register_wall_object(World *world, int x, int y, int dir,
+                                int id);
+void world_register_object(World *world, int x, int y, int id);
+void world_remove_object(World *world, int x, int y, int id);
+void world_remove_wall_object(World *world, int x, int y, int k, int id);
+void world_add_models(World *world, GameModel **models);
+void world_reset(World *world, int dispose);
 #endif


### PR DESCRIPTION
The following functions were renamed:

```
world_load_section_from3 -> world_load_section
world_remove_object2 -> world_register_object
world_set_object_adjacency_from4 -> world_register_wall_object
world_set_object_adjacency_from3 -> world_set_blocked
world_method407 -> world_set_unblocked
world_method425 -> world_vertex_shadow
world_method404 -> world_update_shadow_rect
world_get_tile_decoration_from4 -> world_decoration_or_colour
world_load_section_from4 -> world_load_assemble
world_set_tiles -> world_fill_edges
```