### PR TITLE
Fix issues found by -Wstrict-prototypes -Wmissing-prototypes

### DIFF
--- a/src/custom/clarify-herblaw-items.c
+++ b/src/custom/clarify-herblaw-items.c
@@ -1,3 +1,4 @@
+#include "../custom/clarify-herblaw-items.h"
 #include "../game-data.h"
 #include "../utility.h"
 #include <assert.h>

--- a/src/game-data.c
+++ b/src/game-data.c
@@ -5,6 +5,11 @@
 
 struct MudConfig game_data;
 
+static int game_data_get_unsigned_byte(void);
+static int game_data_get_unsigned_short(void);
+static int game_data_get_unsigned_int(void);
+static char *game_data_get_string(void);
+
 int game_data_get_model_index(char *name) {
     strtolower(name);
 
@@ -23,19 +28,19 @@ int game_data_get_model_index(char *name) {
     return game_data.model_count - 1;
 }
 
-static int game_data_get_unsigned_byte() {
+static int game_data_get_unsigned_byte(void) {
     return get_unsigned_byte(game_data.data_integer, game_data.offset++,
                              game_data.data_integer_len);
 }
 
-static int game_data_get_unsigned_short() {
+static int game_data_get_unsigned_short(void) {
     int i = get_unsigned_short(game_data.data_integer, game_data.offset,
                                game_data.data_integer_len);
     game_data.offset += 2;
     return i;
 }
 
-static int game_data_get_unsigned_int() {
+static int game_data_get_unsigned_int(void) {
     int i = get_unsigned_int(game_data.data_integer, game_data.offset,
                              game_data.data_integer_len);
     game_data.offset += 4;
@@ -47,7 +52,7 @@ static int game_data_get_unsigned_int() {
     return i;
 }
 
-static char *game_data_get_string() {
+static char *game_data_get_string(void) {
     int start = game_data.string_offset;
 
     while (game_data.data_string[game_data.string_offset]) {

--- a/src/mudclient.h
+++ b/src/mudclient.h
@@ -1141,8 +1141,10 @@ void mudclient_draw_blue_bar(mudclient *mud);
 int mudclient_is_in_combat(mudclient *mud);
 GameCharacter *mudclient_get_opponent(mudclient *mud);
 void mudclient_draw_ui(mudclient *mud);
+int mudclient_compare_text(const void *v1, const void *v2);
 void mudclient_draw_overhead(mudclient *mud);
 void mudclient_animate_objects(mudclient *mud);
+void mudclient_draw_entity_sprites(mudclient *mud);
 void mudclient_draw_game(mudclient *mud);
 void mudclient_reset_game(mudclient *mud);
 void mudclient_login(mudclient *mud, char *username, char *password,

--- a/src/packet-stream.c
+++ b/src/packet-stream.c
@@ -51,10 +51,12 @@ int get_client_opcode_friend(int opcode) {
     return -1;
 }
 
-void init_packet_stream_global() { THREAT_LENGTH = strlen(SPOOKY_THREAT); }
+void init_packet_stream_global(void) { THREAT_LENGTH = strlen(SPOOKY_THREAT); }
 #endif
 
 #ifdef HAVE_SIGNALS
+void on_signal_do_nothing(int dummy);
+
 void on_signal_do_nothing(int dummy) { (void)dummy; }
 #endif
 

--- a/src/packet-stream.h
+++ b/src/packet-stream.h
@@ -63,7 +63,7 @@ typedef struct PacketStream PacketStream;
 #include "utility.h"
 
 #ifdef REVISION_177
-void init_packet_stream_global();
+void init_packet_stream_global(void);
 #endif
 
 struct PacketStream {

--- a/src/surface.c
+++ b/src/surface.c
@@ -27,7 +27,9 @@ int character_width[256] = {0};
 
 int32_t *surface_texture_pixels = NULL;
 
-void init_surface_global() {
+static int surface_blend_alpha(int background_colour, int colour, int alpha);
+
+void init_surface_global(void) {
     memset(game_fonts, '\0', sizeof(game_fonts));
 
     for (int i = 0; i < 256; i++) {
@@ -2699,7 +2701,7 @@ void surface_plot_scale_from13(int32_t *dest, int32_t *src, int j, int k,
     }
 }
 
-int surface_blend_alpha(int background_colour, int colour, int alpha) {
+static int surface_blend_alpha(int background_colour, int colour, int alpha) {
     int background_alpha = 256 - alpha;
 
     return ((((colour & 0xff00ff) * alpha +

--- a/src/surface.h
+++ b/src/surface.h
@@ -144,7 +144,7 @@ extern int8_t *game_fonts[50];
 extern int character_width[256];
 extern int32_t *surface_texture_pixels;
 
-void init_surface_global();
+void init_surface_global(void);
 
 struct Surface {
     int limit;

--- a/src/ui/additional-options.c
+++ b/src/ui/additional-options.c
@@ -4,15 +4,24 @@
 
 const char *option_tabs[] = {"Game", "Controls", "UI", "Bank"};
 
-int mudclient_add_option_panel_label(Panel *panel, char *label, int x, int y) {
+static int mudclient_add_option_panel_label(Panel *panel, char *label,
+                                            int x, int y);
+static int mudclient_add_option_panel_string(Panel *panel, char *label,
+                                             char *default_text,
+                                             int max_length, int x, int y);
+static int mudclient_add_option_panel_checkbox(Panel *panel, char *label,
+                                               int is_checked, int x, int y);
+
+static int mudclient_add_option_panel_label(Panel *panel, char *label,
+                                            int x, int y) {
     panel_add_text(panel, x, y, label, 1, 0);
 
     return surface_text_width(label, 1) + 2;
 }
 
-int mudclient_add_option_panel_string(Panel *panel, char *label,
-                                      char *default_text, int max_length, int x,
-                                      int y) {
+static int mudclient_add_option_panel_string(Panel *panel, char *label,
+                                             char *default_text, int max_length,
+                                             int x, int y) {
     int label_width = mudclient_add_option_panel_label(panel, label, x, y);
 
     int control = panel_add_text_input(panel, x + label_width, y,
@@ -24,8 +33,8 @@ int mudclient_add_option_panel_string(Panel *panel, char *label,
     return control;
 }
 
-int mudclient_add_option_panel_checkbox(Panel *panel, char *label,
-                                        int is_checked, int x, int y) {
+static int mudclient_add_option_panel_checkbox(Panel *panel, char *label,
+                                               int is_checked, int x, int y) {
     int label_width = mudclient_add_option_panel_label(panel, label, x, y);
 
     int control = panel_add_checkbox(panel, x + label_width, y - 7, 14, 14);

--- a/src/ui/additional-options.h
+++ b/src/ui/additional-options.h
@@ -21,10 +21,6 @@
 
 extern const char *option_tabs[];
 
-int mudclient_add_option_panel_label(Panel *panel, char *label, int x, int y);
-int mudclient_add_option_panel_string(Panel *panel, char *label,
-                                      char *default_text, int max_length, int x,
-                                      int y);
 void mudclient_create_options_panel(mudclient *mud);
 Panel *mudclient_get_active_option_panel(mudclient *mud);
 void mudclient_get_active_options(mudclient *mud, void ***options,

--- a/src/ui/bank.c
+++ b/src/ui/bank.c
@@ -1,5 +1,8 @@
 #include "bank.h"
 
+static void mudclient_draw_bank_page(mudclient *mud, int x, int y, int page,
+                                     int width);
+
 /* handle withdrawing or depositing */
 void mudclient_bank_transaction(mudclient *mud, int item_id, int amount,
                                 int opcode) {
@@ -84,8 +87,8 @@ void mudclient_bank_transaction(mudclient *mud, int item_id, int amount,
 }
 
 /* draw the page numbers in the title bar */
-void mudclient_draw_bank_page(mudclient *mud, int x, int y, int page,
-                              int width) {
+static void mudclient_draw_bank_page(mudclient *mud, int x, int y, int page,
+                                     int width) {
     int text_colour = WHITE;
 
     if (mud->bank_active_page == page - 1) {

--- a/src/ui/duel.c
+++ b/src/ui/duel.c
@@ -1,7 +1,11 @@
 #include "duel.h"
 
-void mudclient_draw_duel_option(mudclient *mud, int x, int y, int width,
-                                int option) {
+
+static void mudclient_draw_duel_option(mudclient *mud, int x, int y, int width,
+                                       int option);
+
+static void mudclient_draw_duel_option(mudclient *mud, int x, int y, int width,
+                                       int option) {
     surface_draw_border(mud->surface, x + width, y, DUEL_CHECKBOX_WIDTH,
                         DUEL_CHECKBOX_HEIGHT, YELLOW);
 

--- a/src/ui/stats-tab.c
+++ b/src/ui/stats-tab.c
@@ -41,7 +41,7 @@ static const char *members_quests[] = {
 char **quest_names;
 int quests_length = 0;
 
-void init_stats_tab_global() {
+void init_stats_tab_global(void) {
     skills_length = sizeof(skill_names) / sizeof(skill_names[0]);
 
     int total_exp = 0;

--- a/src/ui/stats-tab.h
+++ b/src/ui/stats-tab.h
@@ -15,7 +15,7 @@ extern int quests_length;
 #define STATS_TAB_HEIGHT 24
 #define STATS_LINE_BREAK (MUD_IS_COMPACT ? 11 : 12)
 
-void init_stats_tab_global();
+void init_stats_tab_global(void);
 
 void mudclient_draw_equipment_status(mudclient *mud, int x, int y,
                                      int line_break, int no_menus);

--- a/src/ui/ui-tabs.c
+++ b/src/ui/ui-tabs.c
@@ -3,6 +3,8 @@
 char *mudclient_ui_tab_names[] = {"Inventory", "Map",     "Stats",
                                   "Spellbook", "Friends", "Options"};
 
+static void mudclient_toggle_ui_tab(mudclient *mud, int tab);
+
 void mudclient_draw_inventory_count(mudclient *mud) {
     int is_touch = mudclient_is_touch(mud);
 
@@ -112,7 +114,7 @@ void mudclient_draw_ui_tabs(mudclient *mud) {
     mudclient_draw_inventory_count(mud);
 }
 
-void mudclient_toggle_ui_tab(mudclient *mud, int tab) {
+static void mudclient_toggle_ui_tab(mudclient *mud, int tab) {
     if (mud->mouse_button_click != 0) {
         mud->show_ui_tab = mud->show_ui_tab == tab ? 0 : tab;
         mud->mouse_button_click = 0;

--- a/src/utility.c
+++ b/src/utility.c
@@ -19,7 +19,7 @@ int certificate_items[][2] = {
     {1274, 495}, {631, 545}, {630, 546},  {629, 554},  {628, 555},  {713, 633},
     {712, 634},  {711, 635}, {1270, 814}};
 
-void init_utility_global() {
+void init_utility_global(void) {
     for (int i = 0; i < 256; i++) {
         sin_cos_512[i] = (int)(sin((double)i * 0.02454369) * 32768);
         sin_cos_512[i + 256] = (int)(cos((double)i * 0.02454369) * 32768);
@@ -598,7 +598,7 @@ void format_confirm_amount(int amount, char *formatted) {
     }
 }
 
-int get_ticks() {
+int get_ticks(void) {
 #if !defined(WII) && !defined(_3DS)
     return SDL_GetTicks();
 #endif

--- a/src/utility.h
+++ b/src/utility.h
@@ -107,7 +107,7 @@ extern int _3ds_gl_framebuffer_offsets_x[];
 extern int _3ds_gl_framebuffer_offsets_y[];
 #endif
 
-void init_utility_global();
+void init_utility_global(void);
 
 void mud_log(char *format, ...);
 void mud_error(char *format, ...);
@@ -138,7 +138,7 @@ void *unpack_data(const char *file_name, size_t extra_size, void *archive_data,
 void *load_data(const char *file_name, size_t extra_size,
                   void *archive_data, size_t *size_out);
 void format_confirm_amount(int amount, char *formatted);
-int get_ticks();
+int get_ticks(void);
 void delay_ticks(int ticks);
 void get_level_difference_colour(int level_difference, char *colour);
 void ulaw_to_linear(long size, uint8_t *u_ptr, int16_t *out_ptr);

--- a/src/world.c
+++ b/src/world.c
@@ -25,7 +25,7 @@ static int world_get_tile_type(World *, int, int);
 
 int16_t terrain_colours[TERRAIN_COLOUR_COUNT];
 
-void init_world_global() {
+void init_world_global(void) {
     for (int i = 0; i < 64; i++) {
         terrain_colours[i] = scene_rgb_to_fill(
             255 - i * 4, 255 - (int)((double)i * 1.75), 255 - i * 4);

--- a/src/world.h
+++ b/src/world.h
@@ -65,7 +65,7 @@ typedef enum TILE_TIPE {
 extern int16_t terrain_colours[TERRAIN_COLOUR_COUNT];
 
 int rgb_to_texture_colour(int r, int g, int b);
-void init_world_global();
+void init_world_global(void);
 
 struct World {
     Scene *scene;


### PR DESCRIPTION
Some of this is C99 compliance stuff, e.g. declaring functions with () for empty arguments is deprecated.