### PR TITLE
Win9X Requires a Pentium Pro

### DIFF
--- a/Makefile.win9x
+++ b/Makefile.win9x
@@ -2,7 +2,7 @@ CC = C:\gcc_win98\bin\gcc
 #DEBUG = 1
 SRC = $(wildcard src/*.c src/lib/*.c src/ui/*.c src/custom/*.c win9x/*.c)
 OBJ = $(SRC:.c=.o)
-CFLAGS = -I ./cglm/include -DRENDER_SW -DSDL12 -DWIN9X -DSDL_MAIN_HANDLED -DREVISION_177 #-DUSE_LOCOLOUR
+CFLAGS = -fwrapv -std=gnu99 -I ./cglm/include -DRENDER_SW -DSDL12 -DWIN9X -DSDL_MAIN_HANDLED -DREVISION_177 #-DUSE_LOCOLOUR
 CFLAGS += -I ./SDL-1.2.15/include/SDL #-fPIE
 CFLAGS += -I ./SDL_image-1.2.12/include
 LDFLAGS = -lm -L ./SDL-1.2.15/lib -lmingw32
@@ -12,7 +12,7 @@ LDFLAGS += -lSDL_image -lSDL -lwsock32 -lws2_32 -mwindows
 ifdef DEBUG
 CFLAGS += -Wall -Wextra -pedantic -g
 else
-CFLAGS += -march=pentiumpro -mtune=pentiumpro -fwrapv -std=gnu99 -s -O3 -ffast-math
+CFLAGS += -march=pentiumpro -mtune=pentiumpro -s -O3 -ffast-math
 LDFLAGS += -s
 endif
 

--- a/Makefile.win9x
+++ b/Makefile.win9x
@@ -13,7 +13,7 @@ LDFLAGS += -lSDL_image -lSDL -lwsock32 -lws2_32 -mwindows
 ifdef DEBUG
 CFLAGS += -Wall -Wextra -pedantic -g
 else
-CFLAGS += -march=pentium -mtune=pentium -s -Ofast
+CFLAGS += -march=pentiumpro -mtune=pentiumpro -s -O3 -ffast-math
 LDFLAGS += -s
 endif
 

--- a/Makefile.win9x
+++ b/Makefile.win9x
@@ -2,18 +2,17 @@ CC = C:\gcc_win98\bin\gcc
 #DEBUG = 1
 SRC = $(wildcard src/*.c src/lib/*.c src/ui/*.c src/custom/*.c win9x/*.c)
 OBJ = $(SRC:.c=.o)
-CFLAGS = -I ./cglm/include -I ./glew-2.1.0/include -DRENDER_SW -DSDL12 -DWIN9X -DSDL_MAIN_HANDLED -DREVISION_177 #-DUSE_LOCOLOUR
+CFLAGS = -I ./cglm/include -DRENDER_SW -DSDL12 -DWIN9X -DSDL_MAIN_HANDLED -DREVISION_177 #-DUSE_LOCOLOUR
 CFLAGS += -I ./SDL-1.2.15/include/SDL #-fPIE
 CFLAGS += -I ./SDL_image-1.2.12/include
 LDFLAGS = -lm -L ./SDL-1.2.15/lib -lmingw32
 LDFLAGS += -L ./SDL_image-1.2.12/lib/x86
-LDFLAGS += -L ./glew-2.1.0/lib/Release/Win32/ -lopengl32 -lglu32 -lglew32
 LDFLAGS += -lSDL_image -lSDL -lwsock32 -lws2_32 -mwindows
 
 ifdef DEBUG
 CFLAGS += -Wall -Wextra -pedantic -g
 else
-CFLAGS += -march=pentiumpro -mtune=pentiumpro -s -O3 -ffast-math
+CFLAGS += -march=pentiumpro -mtune=pentiumpro -fwrapv -std=gnu99 -s -O3 -ffast-math
 LDFLAGS += -s
 endif
 

--- a/README.md
+++ b/README.md
@@ -98,8 +98,17 @@ inside C:\mingw\bin copy the mingw32-make.exe as make.exe
 
 edit autoexec.bat on drive C and add
 ```
-PATH=C:\mingw\bin
+    PATH=C:\mingw\bin
 ```
+
+then run the following in a command window
+
+```
+    make -f Makefile.win9x
+```
+
+distribute with `./SDL.dll`, `./SDL_image.dll`, and `./cache` directory.
+
 test locally.
 
 ### run requirements
@@ -113,11 +122,6 @@ windows 95 or 98
 note OS must have winsock 2
 
 on windows 95 might need to install ws2setup.exe
-
-    make -f Makefile.win9x
-    mudclient.exe
-
-distribute with `./SDL.dll`, `./SDL_image.dll`, and `./cache` directory.
 
 ## build (web)
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ distribute with `./SDL2.dll`, `./glew32.dll` and `./cache` directory.
 
 ## build (windows 9x)
 
+building requires at least 256MB of ram and a pentium pro or greater processor
+
 download [gcc-win98](https://github.com/fsb4000/gcc-for-Windows98/releases).
 
 download [mingw](https://sourceforge.net/projects/mingw/files/MinGW/Extension/make/mingw32-make-3.80-3/).
@@ -94,11 +96,15 @@ install mingw to C:\mingw
 
 inside C:\mingw\bin copy the mingw32-make.exe as make.exe
 
+edit autoexec.bat on drive C and add
+```
+PATH=C:\mingw\bin
+```
 test locally.
 
 ### run requirements
 
-pentium processor
+pentium pro or greater processor
 
 64MB of ram
 
@@ -111,7 +117,7 @@ on windows 95 might need to install ws2setup.exe
     make -f Makefile.win9x
     mudclient.exe
 
-distribute with `./SDL-1.2.15/bin/SDL.dll`, and `./cache` directory.
+distribute with `./SDL.dll`, `./SDL_image.dll`, and `./cache` directory.
 
 ## build (web)
 

--- a/README.md
+++ b/README.md
@@ -98,13 +98,13 @@ inside C:\mingw\bin copy the mingw32-make.exe as make.exe
 
 edit autoexec.bat on drive C and add
 ```
-    PATH=C:\mingw\bin
+PATH=C:\mingw\bin
 ```
 
 then run the following in a command window
 
 ```
-    make -f Makefile.win9x
+make -f Makefile.win9x
 ```
 
 distribute with `./SDL.dll`, `./SDL_image.dll`, and `./cache` directory.

--- a/README.md
+++ b/README.md
@@ -119,9 +119,9 @@ pentium pro or greater processor
 
 windows 95 or 98
 
-note OS must have winsock 2
+note OS must have comctl32, winsock 2, and msvctr
 
-on windows 95 might need to install ws2setup.exe
+on windows 95 might need to install ws2setup.exe, 401comupd.exe, and find a copy of msvctr.dll
 
 ## build (web)
 


### PR DESCRIPTION
Changes the makefile to properly target a Pentium Pro and updated the readme.