### PR TITLE
Fix additional options overflowing the interface again

### DIFF
--- a/src/ui/additional-options.c
+++ b/src/ui/additional-options.c
@@ -148,15 +148,6 @@ void mudclient_create_options_panel(mudclient *mud) {
 
     control = mudclient_add_option_panel_checkbox(
         mud->panel_game_options,
-        "@whi@Certificate items: ", mud->options->certificate_items, x, y);
-
-    mud->game_options[control] = &mud->options->certificate_items;
-    mud->game_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
-
-    y += OPTION_HORIZ_GAP;
-
-    control = mudclient_add_option_panel_checkbox(
-        mud->panel_game_options,
         "@whi@HQ sprites (restart): ", mud->options->tga_sprites, x, y);
 
     mud->game_options[control] = &mud->options->tga_sprites;


### PR DESCRIPTION
"Certificate items" was accidentally duplicated during a merge.

Ideas for future: merge total/remaining XP options (they both need to increase the height of the skills menu beyond vanilla)