### PR TITLE
menu: Refactor, allow menus and "more options" to exceed the maximum of 19.

### DIFF
--- a/src/mudclient.c
+++ b/src/mudclient.c
@@ -658,6 +658,10 @@ void mudclient_new(mudclient *mud) {
     mud->camera_rotation_y_increment = 2;
     mud->last_plane_index = -1;
 
+    mud->menu_items_size = 32;
+    mud->menu_items = calloc(mud->menu_items_size, sizeof(struct MenuEntry));
+    mud->menu_indices = calloc(mud->menu_items_size, sizeof(int));
+
     mud->options = malloc(sizeof(Options));
 
     options_new(mud->options);

--- a/src/mudclient.h
+++ b/src/mudclient.h
@@ -182,7 +182,7 @@
 #define OVERWORLD_TEXT_MAX 128
 
 #define INVENTORY_ITEMS_MAX 30
-#define MENU_MAX 250
+#define MENU_MAX 500
 #define PATH_STEPS_MAX 8000
 #define BANK_ITEMS_MAX 256
 #define SHOP_ITEMS_MAX 256 // TODO also just make this 40? (SHOP_GRID_MAX)
@@ -473,6 +473,17 @@ struct OverworldText {
     uint16_t x;
     uint16_t y;
     uint32_t colour;
+};
+
+struct MenuEntry {
+    MenuType type;
+    char action_text[64];
+    char target_text[64];
+    /* data related to the target entity */
+    int x, y;
+    uint16_t index;
+    uint16_t source_index;
+    uint16_t target_index;
 };
 
 struct mudclient {
@@ -855,16 +866,9 @@ struct mudclient {
 
     /* ./ui/menu.c */
     int8_t show_right_click_menu;
-    int menu_items_count;
-    int menu_indices[MENU_MAX];
-    int menu_item_x[MENU_MAX];
-    int menu_item_y[MENU_MAX];
-    char menu_item_text1[MENU_MAX][64];
-    char menu_item_text2[MENU_MAX][64];
-    int menu_index[MENU_MAX];
-    int menu_source_index[MENU_MAX];
-    int menu_target_index[MENU_MAX];
-    MenuType menu_type[MENU_MAX];
+    int16_t menu_items_count;
+    int16_t menu_indices[MENU_MAX];
+    struct MenuEntry menu_items[MENU_MAX];
     int menu_width;
     int menu_height;
     int menu_x;

--- a/src/mudclient.h
+++ b/src/mudclient.h
@@ -182,7 +182,6 @@
 #define OVERWORLD_TEXT_MAX 128
 
 #define INVENTORY_ITEMS_MAX 30
-#define MENU_MAX 500
 #define PATH_STEPS_MAX 8000
 #define BANK_ITEMS_MAX 256
 #define SHOP_ITEMS_MAX 256 // TODO also just make this 40? (SHOP_GRID_MAX)
@@ -479,6 +478,7 @@ struct MenuEntry {
     MenuType type;
     char action_text[64];
     char target_text[64];
+    char wiki_page[64];
     /* data related to the target entity */
     int x, y;
     uint16_t index;
@@ -867,13 +867,13 @@ struct mudclient {
     /* ./ui/menu.c */
     int8_t show_right_click_menu;
     int16_t menu_items_count;
-    int16_t menu_indices[MENU_MAX];
-    struct MenuEntry menu_items[MENU_MAX];
+    int16_t menu_items_size;
+    int16_t *menu_indices;
+    struct MenuEntry *menu_items;
     int menu_width;
     int menu_height;
     int menu_x;
     int menu_y;
-    char menu_wiki_page[MENU_MAX][192];
 
     /* ./ui/inventory-tab.c */
     int inventory_items_count;

--- a/src/scene.c
+++ b/src/scene.c
@@ -174,6 +174,12 @@ void scene_new(Scene *scene, Surface *surface, int model_count,
     scene->mouse_picked_faces = calloc(scene->max_mouse_picked,
                                         sizeof(int));
 
+#ifndef RENDER_SW
+    scene->gl_mouse_picked_size = 32;
+    scene->gl_mouse_picked_time = calloc(scene->gl_mouse_picked_size,
+                                         sizeof(GlModelTime*));
+#endif
+
     scene->clip_near = 5;
     // scene->view_distance = 9;
     scene->view_distance = 512;
@@ -4337,6 +4343,21 @@ void scene_gl_render(Scene *scene) {
                     scene->gl_terrain_walkable = 1;
                 } else {
                     GlModelTime model_time = {game_model, time};
+
+
+                    if (scene->gl_mouse_picked_size < (scene->gl_mouse_picked_count / 2)) {
+                        size_t new_size = scene->gl_mouse_picked_count * 2;
+                        void *new_ptr = NULL;
+
+                        new_ptr = realloc(scene->gl_mouse_picked_time,
+                                          new_size * sizeof(GlModelTime *));
+                        if (new_ptr == NULL) {
+                            return;
+                        }
+                        scene->gl_mouse_picked_time = new_ptr;
+                        scene->gl_mouse_picked_size = new_size;
+                    }
+
 
                     scene->gl_mouse_picked_time[scene->gl_mouse_picked_count] =
                         model_time;

--- a/src/scene.c
+++ b/src/scene.c
@@ -6,6 +6,7 @@ static void scene_initialise_polygon_2d(Scene *scene, int polygon_index);
 static void scene_initialise_polygons_2d(Scene *scene);
 
 #ifdef RENDER_SW
+static void scene_mouse_pick(Scene *scene, GameModel *model, int face);
 static void scene_texture128_scanline(int32_t *restrict raster,
                                       int32_t *restrict texture, int k, int l,
                                       int i1, int j1, int k1, int l1,
@@ -57,6 +58,32 @@ static int scene_heuristic_polygon(GamePolygon *polygon_a,
 static void scene_initialise_polygon_3d(Scene *scene, int polygon_index);
 static void scene_render_polygon_2d_face(Scene *scene, int face);
 #endif
+
+static void scene_mouse_pick(Scene *scene, GameModel *model, int face) {
+    if (scene->mouse_picked_count > (scene->max_mouse_picked / 2)) {
+        size_t new_max = scene->max_mouse_picked * 2;
+        void *new_ptr;
+
+        new_ptr = realloc(scene->mouse_picked_models,
+                          new_max * sizeof(GameModel *));
+        if (new_ptr == NULL) {
+            return;
+        }
+        scene->mouse_picked_models = new_ptr;
+
+        new_ptr = realloc(scene->mouse_picked_faces,
+                          new_max * sizeof(int));
+        if (new_ptr == NULL) {
+            return;
+        }
+        scene->mouse_picked_faces = new_ptr;
+        scene->max_mouse_picked = new_max;
+    }
+
+    scene->mouse_picked_models[scene->mouse_picked_count] = model;
+    scene->mouse_picked_faces[scene->mouse_picked_count] = face;
+    scene->mouse_picked_count++;
+}
 
 #ifdef RENDER_3DS_GL
 void _3ds_gl_perspective(float fov, float aspect, float near, float far,
@@ -140,6 +167,12 @@ void scene_new(Scene *scene, Surface *surface, int model_count,
     scene->max_model_count = model_count;
     scene->max_polygon_count = polygon_count;
     scene->max_sprite_count = max_sprite_count;
+
+    scene->max_mouse_picked = 32;
+    scene->mouse_picked_models = calloc(scene->max_mouse_picked,
+                                        sizeof(GameModel *));
+    scene->mouse_picked_faces = calloc(scene->max_mouse_picked,
+                                        sizeof(int));
 
     scene->clip_near = 5;
     // scene->view_distance = 9;
@@ -1254,8 +1287,7 @@ static void scene_render_polygon_2d_face(Scene *scene, int face) {
                                (256 * scene->view_distance) / project_z,
                                depth_top, depth_bottom);
 
-    if (scene->mouse_picking_active &&
-        scene->mouse_picked_count < MOUSE_PICKED_MAX) {
+    if (scene->mouse_picking_active) {
         // x += (scene->sprite_translate_x[face] << scene->view_distance) /
         // project_z;
         x += (scene->sprite_translate_x[face] * scene->view_distance) /
@@ -1265,9 +1297,8 @@ static void scene_render_polygon_2d_face(Scene *scene, int face) {
             scene->mouse_x >= x && scene->mouse_x <= x + width &&
             !scene->view->unpickable &&
             scene->view->is_local_player[face] == 0) {
-            scene->mouse_picked_models[scene->mouse_picked_count] = scene->view;
-            scene->mouse_picked_faces[scene->mouse_picked_count] = face;
-            scene->mouse_picked_count++;
+
+            scene_mouse_pick(scene, scene->view, face);
         }
     }
 }
@@ -2256,7 +2287,6 @@ static void scene_generate_scanlines(Scene *scene, int plane, int32_t *plane_x,
     }
 
     if (scene->mouse_picking_active &&
-        scene->mouse_picked_count < MOUSE_PICKED_MAX &&
         scene->mouse_y >= scene->min_y && scene->mouse_y < scene->max_y) {
         Scanline *scanline_1 = &scene->scanlines[scene->mouse_y];
 
@@ -2265,9 +2295,7 @@ static void scene_generate_scanlines(Scene *scene, int plane, int32_t *plane_x,
             scanline_1->start_x <= scanline_1->end_x &&
             !game_model->unpickable && game_model->is_local_player[face] == 0) {
 
-            scene->mouse_picked_models[scene->mouse_picked_count] = game_model;
-            scene->mouse_picked_faces[scene->mouse_picked_count] = face;
-            scene->mouse_picked_count++;
+            scene_mouse_pick(scene, game_model, face);
         }
     }
 }
@@ -4329,13 +4357,8 @@ void scene_gl_render(Scene *scene) {
           sizeof(GlModelTime), scene_gl_model_time_compare);
 
     for (int i = 0; i < scene->gl_mouse_picked_count; i++) {
-        scene->mouse_picked_models[scene->mouse_picked_count + i] =
-            scene->gl_mouse_picked_time[i].game_model;
-
-        scene->mouse_picked_faces[scene->mouse_picked_count + i] = -1;
+        scene_mouse_pick(scene, scene->gl_mouse_picked_time[i].game_model, -1);
     }
-
-    scene->mouse_picked_count += scene->gl_mouse_picked_count;
 
     scene->surface->width = old_width;
     scene->surface->height = old_height;
@@ -4586,13 +4609,8 @@ void scene_3ds_gl_render(Scene *scene) {
           sizeof(GlModelTime), scene_gl_model_time_compare);
 
     for (int i = 0; i < scene->gl_mouse_picked_count; i++) {
-        scene->mouse_picked_models[scene->mouse_picked_count + i] =
-            scene->gl_mouse_picked_time[i].game_model;
-
-        scene->mouse_picked_faces[scene->mouse_picked_count + i] = -1;
+        scene_mouse_pick(scene, scene->gl_mouse_picked_time[i].game_model, -1);
     }
-
-    scene->mouse_picked_count += scene->gl_mouse_picked_count;
 }
 
 void scene_3ds_gl_render_transparent_models(Scene *scene) {

--- a/src/scene.h
+++ b/src/scene.h
@@ -61,8 +61,6 @@ typedef struct Scene Scene;
  * function that was unused */
 #define RAMP_WIDE 0
 
-#define MOUSE_PICKED_MAX 100
-
 /* originally 12345678 - this way we save on memory. */
 #define COLOUR_TRANSPARENT INT16_MAX
 
@@ -107,6 +105,7 @@ struct Scene {
     int max_model_count;
     int max_polygon_count;
     int max_sprite_count;
+    int max_mouse_picked;
     GameModel **models;
     GameModel *view;
     int32_t *raster;
@@ -141,8 +140,8 @@ struct Scene {
     int mouse_x;
     int mouse_y;
     int mouse_picked_count;
-    GameModel *mouse_picked_models[MOUSE_PICKED_MAX];
-    int mouse_picked_faces[MOUSE_PICKED_MAX];
+    GameModel **mouse_picked_models;
+    int *mouse_picked_faces;
     int width;
     int clip_x;
     int clip_y;

--- a/src/scene.h
+++ b/src/scene.h
@@ -198,7 +198,8 @@ struct Scene {
     int gl_terrain_pick_y;
 
     /* sort based on distance */
-    GlModelTime gl_mouse_picked_time[MOUSE_PICKED_MAX];
+    GlModelTime *gl_mouse_picked_time;
+    int gl_mouse_picked_size;
 
     int gl_mouse_picked_count;
 

--- a/src/ui/inventory-tab.c
+++ b/src/ui/inventory-tab.c
@@ -118,17 +118,17 @@ void mudclient_draw_ui_tab_inventory(mudclient *mud, int no_menus) {
     } else {
         if (mud->selected_spell >= 0) {
             if (game_data.spells[mud->selected_spell].type == 3) {
-                sprintf(mud->menu_item_text1[mud->menu_items_count],
+                sprintf(mud->menu_items[mud->menu_items_count].action_text,
                         "Cast %s on",
                         game_data.spells[mud->selected_spell].name);
 
-                strcpy(mud->menu_item_text2[mud->menu_items_count],
+                strcpy(mud->menu_items[mud->menu_items_count].target_text,
                        formatted_item_name);
 
-                mud->menu_type[mud->menu_items_count] = MENU_CAST_INVITEM;
-                mud->menu_index[mud->menu_items_count] = item_index;
+                mud->menu_items[mud->menu_items_count].type = MENU_CAST_INVITEM;
+                mud->menu_items[mud->menu_items_count].index = item_index;
 
-                mud->menu_source_index[mud->menu_items_count] =
+                mud->menu_items[mud->menu_items_count].source_index =
                     mud->selected_spell;
 
                 mud->menu_items_count++;
@@ -137,16 +137,16 @@ void mudclient_draw_ui_tab_inventory(mudclient *mud, int no_menus) {
             }
         } else {
             if (mud->selected_item_inventory_index >= 0) {
-                sprintf(mud->menu_item_text1[mud->menu_items_count],
+                sprintf(mud->menu_items[mud->menu_items_count].action_text,
                         "Use %s with:", mud->selected_item_name);
 
-                strcpy(mud->menu_item_text2[mud->menu_items_count],
+                strcpy(mud->menu_items[mud->menu_items_count].target_text,
                        formatted_item_name);
 
-                mud->menu_type[mud->menu_items_count] = MENU_USEWITH_INVITEM;
-                mud->menu_index[mud->menu_items_count] = item_index;
+                mud->menu_items[mud->menu_items_count].type = MENU_USEWITH_INVITEM;
+                mud->menu_items[mud->menu_items_count].index = item_index;
 
-                mud->menu_source_index[mud->menu_items_count] =
+                mud->menu_items[mud->menu_items_count].source_index =
                     mud->selected_item_inventory_index;
 
                 mud->menu_items_count++;
@@ -155,65 +155,65 @@ void mudclient_draw_ui_tab_inventory(mudclient *mud, int no_menus) {
             }
 
             if (mud->inventory_equipped[item_index] == 1) {
-                strcpy(mud->menu_item_text1[mud->menu_items_count], "Remove");
+                strcpy(mud->menu_items[mud->menu_items_count].action_text, "Remove");
 
-                strcpy(mud->menu_item_text2[mud->menu_items_count],
+                strcpy(mud->menu_items[mud->menu_items_count].target_text,
                        formatted_item_name);
 
-                mud->menu_type[mud->menu_items_count] = MENU_INVENTORY_UNEQUIP;
-                mud->menu_index[mud->menu_items_count] = item_index;
+                mud->menu_items[mud->menu_items_count].type = MENU_INVENTORY_UNEQUIP;
+                mud->menu_items[mud->menu_items_count].index = item_index;
                 mud->menu_items_count++;
             } else if (game_data.items[item_id].wearable != 0) {
                 int is_wield = (game_data.items[item_id].wearable & 24);
 
-                strcpy(mud->menu_item_text1[mud->menu_items_count],
+                strcpy(mud->menu_items[mud->menu_items_count].action_text,
                        is_wield ? "Wield" : "Wear");
 
-                strcpy(mud->menu_item_text2[mud->menu_items_count],
+                strcpy(mud->menu_items[mud->menu_items_count].target_text,
                        formatted_item_name);
 
-                mud->menu_type[mud->menu_items_count] = MENU_INVENTORY_WEAR;
-                mud->menu_index[mud->menu_items_count] = item_index;
+                mud->menu_items[mud->menu_items_count].type = MENU_INVENTORY_WEAR;
+                mud->menu_items[mud->menu_items_count].index = item_index;
                 mud->menu_items_count++;
             }
 
             if (strlen(game_data.items[item_id].command) > 0) {
-                strcpy(mud->menu_item_text1[mud->menu_items_count],
+                strcpy(mud->menu_items[mud->menu_items_count].action_text,
                        game_data.items[item_id].command);
 
-                strcpy(mud->menu_item_text2[mud->menu_items_count],
+                strcpy(mud->menu_items[mud->menu_items_count].target_text,
                        formatted_item_name);
 
-                mud->menu_type[mud->menu_items_count] = MENU_INVENTORY_COMMAND;
-                mud->menu_index[mud->menu_items_count] = item_index;
+                mud->menu_items[mud->menu_items_count].type = MENU_INVENTORY_COMMAND;
+                mud->menu_items[mud->menu_items_count].index = item_index;
                 mud->menu_items_count++;
             }
 
-            strcpy(mud->menu_item_text1[mud->menu_items_count], "Use");
+            strcpy(mud->menu_items[mud->menu_items_count].action_text, "Use");
 
-            strcpy(mud->menu_item_text2[mud->menu_items_count],
+            strcpy(mud->menu_items[mud->menu_items_count].target_text,
                    formatted_item_name);
 
-            mud->menu_type[mud->menu_items_count] = MENU_INVENTORY_USE;
-            mud->menu_index[mud->menu_items_count] = item_index;
+            mud->menu_items[mud->menu_items_count].type = MENU_INVENTORY_USE;
+            mud->menu_items[mud->menu_items_count].index = item_index;
             mud->menu_items_count++;
 
-            strcpy(mud->menu_item_text1[mud->menu_items_count], "Drop");
+            strcpy(mud->menu_items[mud->menu_items_count].action_text, "Drop");
 
-            strcpy(mud->menu_item_text2[mud->menu_items_count],
+            strcpy(mud->menu_items[mud->menu_items_count].target_text,
                    formatted_item_name);
 
-            mud->menu_type[mud->menu_items_count] = MENU_INVENTORY_DROP;
-            mud->menu_index[mud->menu_items_count] = item_index;
+            mud->menu_items[mud->menu_items_count].type = MENU_INVENTORY_DROP;
+            mud->menu_items[mud->menu_items_count].index = item_index;
             mud->menu_items_count++;
 
-            strcpy(mud->menu_item_text1[mud->menu_items_count], "Examine");
+            strcpy(mud->menu_items[mud->menu_items_count].action_text, "Examine");
 
-            strcpy(mud->menu_item_text2[mud->menu_items_count],
+            strcpy(mud->menu_items[mud->menu_items_count].target_text,
                    formatted_item_name);
 
-            mud->menu_type[mud->menu_items_count] = MENU_INVENTORY_EXAMINE;
-            mud->menu_index[mud->menu_items_count] = item_id;
+            mud->menu_items[mud->menu_items_count].type = MENU_INVENTORY_EXAMINE;
+            mud->menu_items[mud->menu_items_count].index = item_id;
             mud->menu_items_count++;
         }
     }

--- a/src/ui/menu.c
+++ b/src/ui/menu.c
@@ -575,12 +575,6 @@ void mudclient_create_top_mouse_menu(mudclient *mud) {
         return;
     }
 
-    int max_num_on_screen = (mud->game_height / get_entry_height(mud)) - 3;
-
-    if (mud->menu_items_count > max_num_on_screen) {
-        mud->menu_items_count = max_num_on_screen;
-    }
-
     int index = -1;
 
     for (int i = 0; i < mud->menu_items_count; i++) {
@@ -686,20 +680,20 @@ void mudclient_create_top_mouse_menu(mudclient *mud) {
         mud->menu_y = mud->mouse_y - 7;
         mud->show_right_click_menu = 1;
 
-        if (mud->menu_x < 0) {
-            mud->menu_x = 0;
-        }
-
-        if (mud->menu_y < 0) {
-            mud->menu_y = 0;
-        }
-
         if (mud->menu_x + mud->menu_width > mud->surface->width - 2) {
             mud->menu_x = mud->surface->width - 2 - mud->menu_width;
         }
 
         if (mud->menu_y + mud->menu_height > mud->surface->height - 31) {
             mud->menu_y = mud->surface->height - 31 - mud->menu_height;
+        }
+
+        if (mud->menu_x < 0) {
+            mud->menu_x = 0;
+        }
+
+        if (mud->menu_y < 0) {
+            mud->menu_y = 0;
         }
 
         mud->mouse_button_click = 0;

--- a/src/ui/menu.c
+++ b/src/ui/menu.c
@@ -484,12 +484,11 @@ void mudclient_menu_item_click(mudclient *mud, int i) {
         break;
     case MENU_WIKI_LOOKUP: {
         char *page_name = mud->menu_wiki_page[i];
-        int page_name_length = strlen(page_name);
-
-        char encoded_page_name[(page_name_length * 3) + 1];
+        char encoded_page_name[128];
 
         if (strncmp(page_name, "Special:", strlen("Special:")) == 0) {
-            strcpy(encoded_page_name, page_name);
+            snprintf(encoded_page_name, sizeof(encoded_page_name),
+                     "%s", page_name);
         } else {
             url_encode(page_name, encoded_page_name);
         }
@@ -714,9 +713,13 @@ void mudclient_menu_add_wiki(mudclient *mud, const char *display,
     }
 
     strcpy(mud->menu_items[mud->menu_items_count].action_text, "Wiki lookup");
-    strcpy(mud->menu_items[mud->menu_items_count].target_text, display);
+    snprintf(mud->menu_items[mud->menu_items_count].target_text,
+             sizeof(mud->menu_items[mud->menu_items_count].target_text),
+             "%s", display);
     mud->menu_items[mud->menu_items_count].type = MENU_WIKI_LOOKUP;
-    strcpy(mud->menu_wiki_page[mud->menu_items_count], page);
+    snprintf(mud->menu_wiki_page[mud->menu_items_count],
+             sizeof(mud->menu_wiki_page[mud->menu_items_count]),
+             "%s", page);
     mud->menu_items_count++;
 }
 
@@ -748,7 +751,9 @@ void mudclient_menu_add_ground_item(mudclient *mud, int index) {
     snprintf(formatted_item_name, sizeof(formatted_item_name),
         "@lre@%s", item_name);
 
-    strcpy(mud->menu_items[mud->menu_items_count].target_text, formatted_item_name);
+    snprintf(mud->menu_items[mud->menu_items_count].target_text,
+             sizeof(mud->menu_items[mud->menu_items_count].target_text),
+             "%s", formatted_item_name);
 
     mud->menu_items[mud->menu_items_count].x = mud->ground_items[index].x;
     mud->menu_items[mud->menu_items_count].y = mud->ground_items[index].y;
@@ -1040,8 +1045,9 @@ void mudclient_create_right_click_menu(mudclient *mud) {
                                 "Cast %s on",
                                 game_data.spells[mud->selected_spell].name);
 
-                        strcpy(mud->menu_items[mud->menu_items_count].target_text,
-                               formatted_npc_name);
+                        snprintf(mud->menu_items[mud->menu_items_count].target_text,
+                                 sizeof(mud->menu_items[mud->menu_items_count].target_text),
+                                 "%s", formatted_npc_name);
 
                         mud->combat_target = npc;
 
@@ -1095,8 +1101,9 @@ void mudclient_create_right_click_menu(mudclient *mud) {
                     strcpy(mud->menu_items[mud->menu_items_count].action_text,
                            "Talk-to");
 
-                    strcpy(mud->menu_items[mud->menu_items_count].target_text,
-                           formatted_npc_name);
+                    snprintf(mud->menu_items[mud->menu_items_count].target_text,
+                             sizeof(mud->menu_items[mud->menu_items_count].target_text),
+                             "%s", formatted_npc_name);
 
                     mud->menu_items[mud->menu_items_count].type = MENU_NPC_TALK;
                     mud->menu_items[mud->menu_items_count].x = npc->current_x;
@@ -1106,11 +1113,13 @@ void mudclient_create_right_click_menu(mudclient *mud) {
                     mud->menu_items_count++;
 
                     if (strlen(game_data.npcs[npc_id].command) > 0) {
-                        strcpy(mud->menu_items[mud->menu_items_count].action_text,
-                               game_data.npcs[npc_id].command);
+                        snprintf(mud->menu_items[mud->menu_items_count].action_text,
+                                 sizeof(mud->menu_items[mud->menu_items_count].action_text),
+                                 "%s", game_data.npcs[npc_id].command);
 
-                        strcpy(mud->menu_items[mud->menu_items_count].target_text,
-                               formatted_npc_name);
+                        snprintf(mud->menu_items[mud->menu_items_count].target_text,
+                                 sizeof(mud->menu_items[mud->menu_items_count].target_text),
+                                 "%s", formatted_npc_name);
 
                         mud->menu_items[mud->menu_items_count].type =
                             MENU_NPC_COMMAND;
@@ -1130,8 +1139,9 @@ void mudclient_create_right_click_menu(mudclient *mud) {
                     strcpy(mud->menu_items[mud->menu_items_count].action_text,
                            "Examine");
 
-                    strcpy(mud->menu_items[mud->menu_items_count].target_text,
-                           formatted_npc_name);
+                    snprintf(mud->menu_items[mud->menu_items_count].target_text,
+                             sizeof(mud->menu_items[mud->menu_items_count].target_text),
+                             "%s", formatted_npc_name);
 
                     mud->menu_items[mud->menu_items_count].type = MENU_NPC_EXAMINE;
                     mud->menu_items[mud->menu_items_count].index = npc_id;
@@ -1162,8 +1172,9 @@ void mudclient_create_right_click_menu(mudclient *mud) {
                 mudclient_menu_add_id_wiki(mud, formatted_wall_object_name,
                                            "wallobject", wall_object_id);
             } else if (!mud->wall_objects[index].already_in_menu) {
-                strcpy(mud->menu_items[mud->menu_items_count].target_text,
-                       formatted_wall_object_name);
+                snprintf(mud->menu_items[mud->menu_items_count].target_text,
+                         sizeof(mud->menu_items[mud->menu_items_count].target_text),
+                         "%s", formatted_wall_object_name);
 
                 mud->menu_items[mud->menu_items_count].x =
                     mud->wall_objects[index].x;
@@ -1205,8 +1216,9 @@ void mudclient_create_right_click_menu(mudclient *mud) {
                     if (strncasecmp(
                             game_data.wall_objects[wall_object_id].command1,
                             "WalkTo", 6) != 0) {
-                        strcpy(mud->menu_items[mud->menu_items_count].action_text,
-                               game_data.wall_objects[wall_object_id].command1);
+                        snprintf(mud->menu_items[mud->menu_items_count].action_text,
+                                 sizeof(mud->menu_items[mud->menu_items_count].action_text),
+                                  "%s", game_data.wall_objects[wall_object_id].command1);
 
                         mud->menu_items[mud->menu_items_count].type =
                             MENU_WALL_OBJECT_COMMAND1;
@@ -1217,11 +1229,13 @@ void mudclient_create_right_click_menu(mudclient *mud) {
                     if (strncasecmp(
                             game_data.wall_objects[wall_object_id].command2,
                             "Examine", 7) != 0) {
-                        strcpy(mud->menu_items[mud->menu_items_count].action_text,
-                               game_data.wall_objects[wall_object_id].command2);
+                        snprintf(mud->menu_items[mud->menu_items_count].action_text,
+                                 sizeof(mud->menu_items[mud->menu_items_count].action_text),
+                                 "%s", game_data.wall_objects[wall_object_id].command2);
 
-                        strcpy(mud->menu_items[mud->menu_items_count].target_text,
-                               formatted_wall_object_name);
+                        snprintf(mud->menu_items[mud->menu_items_count].target_text,
+                                 sizeof(mud->menu_items[mud->menu_items_count].target_text),
+                                 "%s", formatted_wall_object_name);
 
                         mud->menu_items[mud->menu_items_count].type =
                             MENU_WALL_OBJECT_COMMAND2;
@@ -1266,8 +1280,9 @@ void mudclient_create_right_click_menu(mudclient *mud) {
                 char formatted_object_name[64] = {0};
                 snprintf(formatted_object_name, 64, "@cya@%s", object_name);
 
-                strcpy(mud->menu_items[mud->menu_items_count].target_text,
-                       formatted_object_name);
+                snprintf(mud->menu_items[mud->menu_items_count].target_text,
+                         sizeof(mud->menu_items[mud->menu_items_count].target_text),
+                         "%s", formatted_object_name);
 
                 mud->menu_items[mud->menu_items_count].x = mud->objects[index].x;
                 mud->menu_items[mud->menu_items_count].y = mud->objects[index].y;
@@ -1313,8 +1328,9 @@ void mudclient_create_right_click_menu(mudclient *mud) {
                 } else {
                     if (strncasecmp(game_data.objects[id].command1, "WalkTo",
                                     6) != 0) {
-                        strcpy(mud->menu_items[mud->menu_items_count].action_text,
-                               game_data.objects[id].command1);
+                        snprintf(mud->menu_items[mud->menu_items_count].action_text,
+                                 sizeof(mud->menu_items[mud->menu_items_count].action_text),
+                                 "%s", game_data.objects[id].command1);
 
                         mud->menu_items[mud->menu_items_count].type =
                             MENU_OBJECT_COMMAND1;
@@ -1336,11 +1352,13 @@ void mudclient_create_right_click_menu(mudclient *mud) {
 
                     if (strncasecmp(game_data.objects[id].command2, "Examine",
                                     7) != 0) {
-                        strcpy(mud->menu_items[mud->menu_items_count].action_text,
-                               game_data.objects[id].command2);
+                        snprintf(mud->menu_items[mud->menu_items_count].action_text,
+                                 sizeof(mud->menu_items[mud->menu_items_count].action_text),
+                                 "%s", game_data.objects[id].command2);
 
-                        strcpy(mud->menu_items[mud->menu_items_count].target_text,
-                               formatted_object_name);
+                        snprintf(mud->menu_items[mud->menu_items_count].target_text,
+                                 sizeof(mud->menu_items[mud->menu_items_count].target_text),
+                                 "%s", formatted_object_name);
 
                         mud->menu_items[mud->menu_items_count].type =
                             MENU_OBJECT_COMMAND2;

--- a/src/ui/menu.c
+++ b/src/ui/menu.c
@@ -206,8 +206,9 @@ void mudclient_menu_item_click(mudclient *mud, int i) {
         char *item_name =
             game_data.items[mud->inventory_item_id[menu_index]].name;
 
-        char formatted_drop[strlen(item_name) + 10];
-        sprintf(formatted_drop, "Dropping %s", item_name);
+        char formatted_drop[64];
+        snprintf(formatted_drop, sizeof(formatted_drop),
+            "Dropping %s", item_name);
 
         mudclient_show_message(mud, formatted_drop, MESSAGE_TYPE_BOR);
         break;
@@ -230,10 +231,11 @@ void mudclient_menu_item_click(mudclient *mud, int i) {
                         mudclient_format_number_commas(mud, bank_count,
                                                        formatted_amount);
 
-                        char formatted_total[strlen(item_name) + 31];
+                        char formatted_total[64];
 
-                        sprintf(formatted_total, "Total %s in bank: %s",
-                                item_name, formatted_amount);
+                        snprintf(formatted_total, sizeof(formatted_total),
+                                 "Total %s in bank: %s",
+                                 item_name, formatted_amount);
 
                         mudclient_show_message(mud, formatted_total,
                                                MESSAGE_TYPE_GAME);
@@ -251,10 +253,11 @@ void mudclient_menu_item_click(mudclient *mud, int i) {
                 mudclient_format_number_commas(mud, inventory_amount,
                                                formatted_amount);
 
-                char formatted_total[strlen(item_name) + 36];
+                char formatted_total[64];
 
-                sprintf(formatted_total, "Total %s in inventory: %s", item_name,
-                        formatted_amount);
+                snprintf(formatted_total, sizeof(formatted_total),
+                         "Total %s in inventory: %s", item_name,
+                         formatted_amount);
 
                 mudclient_show_message(mud, formatted_total, MESSAGE_TYPE_GAME);
             }
@@ -491,10 +494,10 @@ void mudclient_menu_item_click(mudclient *mud, int i) {
             url_encode(page_name, encoded_page_name);
         }
 
-        char encoded_url[strlen(mud->options->wiki_url) +
-                         strlen(encoded_page_name) + 1];
+        char encoded_url[256];
 
-        sprintf(encoded_url, mud->options->wiki_url, encoded_page_name);
+        snprintf(encoded_url, sizeof(encoded_url),
+            mud->options->wiki_url, encoded_page_name);
 
 #ifdef EMSCRIPTEN
         EM_ASM(
@@ -504,10 +507,10 @@ void mudclient_menu_item_click(mudclient *mud, int i) {
             },
             encoded_url);
 #else
-        char formatted_command[strlen(encoded_url) +
-                               strlen(mud->options->browser_command) + 1];
+        char formatted_command[256];
 
-        sprintf(formatted_command, mud->options->browser_command, encoded_url);
+        snprintf(formatted_command, sizeof(formatted_command),
+            mud->options->browser_command, encoded_url);
 
         system(formatted_command);
 #endif
@@ -590,7 +593,7 @@ void mudclient_create_top_mouse_menu(mudclient *mud) {
         break;
     }
 
-    char menu_text[255] = {0};
+    char menu_text[256] = {0};
 
 #if !defined(WII) && !defined(_3DS)
     if ((index == -1 || !mud->selected_wiki) && mud->is_hand_cursor) {
@@ -608,7 +611,7 @@ void mudclient_create_top_mouse_menu(mudclient *mud) {
     } else if ((mud->selected_item_inventory_index >= 0 ||
                 mud->selected_spell >= 0) &&
                mud->menu_items_count > 1) {
-        sprintf(menu_text, "@whi@%s %s",
+        snprintf(menu_text, sizeof(menu_text), "@whi@%s %s",
                 mud->menu_items[mud->menu_indices[0]].action_text,
                 mud->menu_items[mud->menu_indices[0]].target_text);
     } else if (index != -1) {
@@ -619,7 +622,7 @@ void mudclient_create_top_mouse_menu(mudclient *mud) {
         }
 #endif
 
-        sprintf(menu_text, "%s: @whi@%s",
+        snprintf(menu_text, sizeof(menu_text), "%s: @whi@%s",
                 mud->menu_items[mud->menu_indices[index]].target_text,
                 mud->menu_items[mud->menu_indices[0]].action_text);
     }
@@ -631,7 +634,8 @@ void mudclient_create_top_mouse_menu(mudclient *mud) {
     if (mud->menu_items_count > 2 && strlen(menu_text) > 0) {
         char more_options[33] = {0};
 
-        sprintf(more_options, "@whi@ / %d more options",
+        snprintf(more_options, sizeof(more_options),
+                "@whi@ / %d more options",
                 mud->menu_items_count - 1);
 
         strcat(menu_text, more_options);
@@ -667,11 +671,10 @@ void mudclient_create_top_mouse_menu(mudclient *mud) {
             char *menu_item_text1 = mud->menu_items[i].action_text;
             char *menu_item_text2 = mud->menu_items[i].target_text;
 
-            char menu_item_text[strlen(menu_item_text1) +
-                                strlen(menu_item_text2) + 2];
+            char menu_item_text[256];
 
-            sprintf(menu_item_text, "%s %s", menu_item_text1,
-                    menu_item_text2);
+            snprintf(menu_item_text, sizeof(menu_item_text),
+                    "%s %s", menu_item_text1, menu_item_text2);
 
             int text_width = surface_text_width(menu_item_text, 1) + 5;
 
@@ -728,13 +731,12 @@ void mudclient_menu_add_id_wiki(mudclient *mud, const char *display,
         }
     }
 
-    char encoded_display[(strlen(name) * 3) + 1];
+    char encoded_display[128];
     url_encode(name, encoded_display);
 
-    char page[strlen(WIKI_TYPE_PAGE) + strlen(type) + strlen(encoded_display) +
-              5];
+    char page[256];
 
-    sprintf(page, WIKI_TYPE_PAGE, type, id, encoded_display);
+    snprintf(page, sizeof(page), WIKI_TYPE_PAGE, type, id, encoded_display);
     mudclient_menu_add_wiki(mud, display, page);
 }
 
@@ -742,8 +744,9 @@ void mudclient_menu_add_ground_item(mudclient *mud, int index) {
     int item_id = mud->ground_items[index].id;
     char *item_name = game_data.items[item_id].name;
 
-    char formatted_item_name[strlen(item_name) + 6];
-    sprintf(formatted_item_name, "@lre@%s", item_name);
+    char formatted_item_name[64];
+    snprintf(formatted_item_name, sizeof(formatted_item_name),
+        "@lre@%s", item_name);
 
     strcpy(mud->menu_items[mud->menu_items_count].target_text, formatted_item_name);
 
@@ -755,7 +758,9 @@ void mudclient_menu_add_ground_item(mudclient *mud, int index) {
         mudclient_menu_add_id_wiki(mud, formatted_item_name, "item", item_id);
     } else if (mud->selected_spell >= 0) {
         if (game_data.spells[mud->selected_spell].type == 3) {
-            sprintf(mud->menu_items[mud->menu_items_count].action_text, "Cast %s on",
+            snprintf(mud->menu_items[mud->menu_items_count].action_text,
+                    sizeof(mud->menu_items[mud->menu_items_count].action_text),
+                    "Cast %s on",
                     game_data.spells[mud->selected_spell].name);
 
             mud->menu_items[mud->menu_items_count].type = MENU_CAST_GROUNDITEM;
@@ -763,7 +768,9 @@ void mudclient_menu_add_ground_item(mudclient *mud, int index) {
             mud->menu_items_count++;
         }
     } else if (mud->selected_item_inventory_index >= 0) {
-        sprintf(mud->menu_items[mud->menu_items_count].action_text, "Use %s with",
+        snprintf(mud->menu_items[mud->menu_items_count].action_text,
+                sizeof(mud->menu_items[mud->menu_items_count].action_text),
+                "Use %s with",
                 mud->selected_item_name);
 
         mud->menu_items[mud->menu_items_count].type = MENU_USEWITH_GROUNDITEM;
@@ -846,17 +853,19 @@ void mudclient_create_right_click_menu(mudclient *mud) {
                 char colour[6] = {0};
                 get_level_difference_colour(level_difference, colour);
 
-                sprintf(level_text, " %s(level-%d)", colour,
-                        mud->players[index]->level);
+                snprintf(level_text, sizeof(level_text),
+                        " %s(level-%d)", colour, mud->players[index]->level);
 
                 if (mud->selected_spell >= 0) {
                     if (game_data.spells[mud->selected_spell].type == 1 ||
                         game_data.spells[mud->selected_spell].type == 2) {
-                        sprintf(mud->menu_items[mud->menu_items_count].action_text,
+                        snprintf(mud->menu_items[mud->menu_items_count].action_text,
+                                sizeof(mud->menu_items[mud->menu_items_count].action_text),
                                 "Cast %s on",
                                 game_data.spells[mud->selected_spell].name);
 
-                        sprintf(mud->menu_items[mud->menu_items_count].target_text,
+                        snprintf(mud->menu_items[mud->menu_items_count].target_text,
+                                sizeof(mud->menu_items[mud->menu_items_count].target_text),
                                 "@whi@%s%s", mud->players[index]->name,
                                 level_text);
 
@@ -880,10 +889,12 @@ void mudclient_create_right_click_menu(mudclient *mud) {
                         mud->menu_items_count++;
                     }
                 } else if (mud->selected_item_inventory_index >= 0) {
-                    sprintf(mud->menu_items[mud->menu_items_count].action_text,
+                    snprintf(mud->menu_items[mud->menu_items_count].action_text,
+                            sizeof(mud->menu_items[mud->menu_items_count].action_text),
                             "Use %s with", mud->selected_item_name);
 
-                    sprintf(mud->menu_items[mud->menu_items_count].target_text,
+                    snprintf(mud->menu_items[mud->menu_items_count].target_text,
+                            sizeof(mud->menu_items[mud->menu_items_count].target_text),
                             "@whi@%s%s", mud->players[index]->name, level_text);
 
                     mud->menu_items[mud->menu_items_count].type = MENU_USEWITH_PLAYER;
@@ -905,7 +916,8 @@ void mudclient_create_right_click_menu(mudclient *mud) {
                         strcpy(mud->menu_items[mud->menu_items_count].action_text,
                                "Attack");
 
-                        sprintf(mud->menu_items[mud->menu_items_count].target_text,
+                        snprintf(mud->menu_items[mud->menu_items_count].target_text,
+                                sizeof(mud->menu_items[mud->menu_items_count].target_text),
                                 "@whi@%s%s", mud->players[index]->name,
                                 level_text);
 
@@ -930,7 +942,8 @@ void mudclient_create_right_click_menu(mudclient *mud) {
                         strcpy(mud->menu_items[mud->menu_items_count].action_text,
                                "Duel with");
 
-                        sprintf(mud->menu_items[mud->menu_items_count].target_text,
+                        snprintf(mud->menu_items[mud->menu_items_count].target_text,
+                                sizeof(mud->menu_items[mud->menu_items_count].target_text),
                                 "@whi@%s%s", mud->players[index]->name,
                                 level_text);
 
@@ -952,7 +965,8 @@ void mudclient_create_right_click_menu(mudclient *mud) {
                     strcpy(mud->menu_items[mud->menu_items_count].action_text,
                            "Trade with");
 
-                    sprintf(mud->menu_items[mud->menu_items_count].target_text,
+                    snprintf(mud->menu_items[mud->menu_items_count].target_text,
+                            sizeof(mud->menu_items[mud->menu_items_count].target_text),
                             "@whi@%s%s", player->name, level_text);
 
                     mud->menu_items[mud->menu_items_count].type = MENU_PLAYER_TRADE;
@@ -965,7 +979,8 @@ void mudclient_create_right_click_menu(mudclient *mud) {
                     strcpy(mud->menu_items[mud->menu_items_count].action_text,
                            "Follow");
 
-                    sprintf(mud->menu_items[mud->menu_items_count].target_text,
+                    snprintf(mud->menu_items[mud->menu_items_count].target_text,
+                            sizeof(mud->menu_items[mud->menu_items_count].target_text),
                             "@whi@%s%s", player->name, level_text);
 
                     mud->menu_items[mud->menu_items_count].type = MENU_PLAYER_FOLLOW;
@@ -984,8 +999,9 @@ void mudclient_create_right_click_menu(mudclient *mud) {
                 int npc_id = npc->npc_id;
                 char *npc_name = game_data.npcs[npc_id].name;
 
-                char formatted_npc_name[strlen(npc_name) + 6];
-                sprintf(formatted_npc_name, "@yel@%s", npc_name);
+                char formatted_npc_name[64];
+                snprintf(formatted_npc_name, sizeof(formatted_npc_name),
+                    "@yel@%s", npc_name);
 
                 if (game_data.npcs[npc_id].attackable > 0) {
                     int npc_level = (game_data.npcs[npc_id].attack +
@@ -1006,7 +1022,8 @@ void mudclient_create_right_click_menu(mudclient *mud) {
                     char colour[6] = "@yel@";
                     get_level_difference_colour(level_difference, colour);
 
-                    sprintf(level_text, " %s(level-%d)", colour, npc_level);
+                    snprintf(level_text, sizeof(level_text),
+                        " %s(level-%d)", colour, npc_level);
                 }
 
                 mud->menu_items[mud->menu_items_count].x = npc->current_x;
@@ -1018,7 +1035,8 @@ void mudclient_create_right_click_menu(mudclient *mud) {
                                                npc_id);
                 } else if (mud->selected_spell >= 0) {
                     if (game_data.spells[mud->selected_spell].type == 2) {
-                        sprintf(mud->menu_items[mud->menu_items_count].action_text,
+                        snprintf(mud->menu_items[mud->menu_items_count].action_text,
+                                sizeof(mud->menu_items[mud->menu_items_count].action_text),
                                 "Cast %s on",
                                 game_data.spells[mud->selected_spell].name);
 
@@ -1035,10 +1053,12 @@ void mudclient_create_right_click_menu(mudclient *mud) {
                         mud->menu_items_count++;
                     }
                 } else if (mud->selected_item_inventory_index >= 0) {
-                    sprintf(mud->menu_items[mud->menu_items_count].action_text,
+                    snprintf(mud->menu_items[mud->menu_items_count].action_text,
+                            sizeof(mud->menu_items[mud->menu_items_count].action_text),
                             "Use %s with", mud->selected_item_name);
 
-                    sprintf(mud->menu_items[mud->menu_items_count].target_text,
+                    snprintf(mud->menu_items[mud->menu_items_count].target_text,
+                            sizeof(mud->menu_items[mud->menu_items_count].target_text),
                             "@yel@%s",
                             game_data.npcs[mud->npcs[index]->npc_id].name);
 
@@ -1053,7 +1073,8 @@ void mudclient_create_right_click_menu(mudclient *mud) {
                         strcpy(mud->menu_items[mud->menu_items_count].action_text,
                                "Attack");
 
-                        sprintf(mud->menu_items[mud->menu_items_count].target_text,
+                        snprintf(mud->menu_items[mud->menu_items_count].target_text,
+                                sizeof(mud->menu_items[mud->menu_items_count].target_text),
                                 "@yel@%s%s",
                                 game_data.npcs[mud->npcs[index]->npc_id].name,
                                 level_text);
@@ -1132,8 +1153,10 @@ void mudclient_create_right_click_menu(mudclient *mud) {
             char *wall_object_name =
                 game_data.wall_objects[wall_object_id].name;
 
-            char formatted_wall_object_name[strlen(wall_object_name) + 6];
-            sprintf(formatted_wall_object_name, "@cya@%s", wall_object_name);
+            char formatted_wall_object_name[64];
+            snprintf(formatted_wall_object_name,
+                     sizeof(formatted_wall_object_name),
+                     "@cya@%s", wall_object_name);
 
             if (mud->selected_wiki) {
                 mudclient_menu_add_id_wiki(mud, formatted_wall_object_name,
@@ -1153,7 +1176,8 @@ void mudclient_create_right_click_menu(mudclient *mud) {
 
                 if (mud->selected_spell >= 0) {
                     if (game_data.spells[mud->selected_spell].type == 4) {
-                        sprintf(mud->menu_items[mud->menu_items_count].action_text,
+                        snprintf(mud->menu_items[mud->menu_items_count].action_text,
+                                sizeof(mud->menu_items[mud->menu_items_count].action_text),
                                 "Cast %s on",
                                 game_data.spells[mud->selected_spell].name);
 
@@ -1166,7 +1190,8 @@ void mudclient_create_right_click_menu(mudclient *mud) {
                         mud->menu_items_count++;
                     }
                 } else if (mud->selected_item_inventory_index >= 0) {
-                    sprintf(mud->menu_items[mud->menu_items_count].action_text,
+                    snprintf(mud->menu_items[mud->menu_items_count].action_text,
+                            sizeof(mud->menu_items[mud->menu_items_count].action_text),
                             "Use %s with", mud->selected_item_name);
 
                     mud->menu_items[mud->menu_items_count].type =
@@ -1216,7 +1241,8 @@ void mudclient_create_right_click_menu(mudclient *mud) {
                     strcpy(mud->menu_items[mud->menu_items_count].action_text,
                            "Examine");
 
-                    sprintf(mud->menu_items[mud->menu_items_count].target_text,
+                    snprintf(mud->menu_items[mud->menu_items_count].target_text,
+                            sizeof(mud->menu_items[mud->menu_items_count].target_text),
                             "@cya@%s",
                             game_data.wall_objects[wall_object_id].name);
 
@@ -1256,11 +1282,13 @@ void mudclient_create_right_click_menu(mudclient *mud) {
                                                "object", object_id);
                 } else if (mud->selected_spell >= 0) {
                     if (game_data.spells[mud->selected_spell].type == 5) {
-                        sprintf(mud->menu_items[mud->menu_items_count].action_text,
+                        snprintf(mud->menu_items[mud->menu_items_count].action_text,
+                                sizeof(mud->menu_items[mud->menu_items_count].action_text),
                                 "Cast %s on",
                                 game_data.spells[mud->selected_spell].name);
 
-                        sprintf(mud->menu_items[mud->menu_items_count].target_text,
+                        snprintf(mud->menu_items[mud->menu_items_count].target_text,
+                                sizeof(mud->menu_items[mud->menu_items_count].target_text),
                                 "@cya@%s", game_data.objects[id].name);
 
                         mud->menu_items[mud->menu_items_count].type =
@@ -1272,7 +1300,8 @@ void mudclient_create_right_click_menu(mudclient *mud) {
                         mud->menu_items_count++;
                     }
                 } else if (mud->selected_item_inventory_index >= 0) {
-                    sprintf(mud->menu_items[mud->menu_items_count].action_text,
+                    snprintf(mud->menu_items[mud->menu_items_count].action_text,
+                            sizeof(mud->menu_items[mud->menu_items_count].action_text),
                             "Use %s with", mud->selected_item_name);
 
                     mud->menu_items[mud->menu_items_count].type = MENU_USEWITH_OBJECT;
@@ -1334,8 +1363,9 @@ void mudclient_create_right_click_menu(mudclient *mud) {
                     strcpy(mud->menu_items[mud->menu_items_count].action_text,
                            "Examine");
 
-                    sprintf(mud->menu_items[mud->menu_items_count].target_text,
-                            "@cya@%s", game_data.objects[id].name);
+                    snprintf(mud->menu_items[mud->menu_items_count].target_text,
+                             sizeof(mud->menu_items[mud->menu_items_count].target_text),
+                             "@cya@%s", game_data.objects[id].name);
 
                     mud->menu_items[mud->menu_items_count].type = MENU_OBJECT_EXAMINE;
                     mud->menu_items[mud->menu_items_count].index = id;
@@ -1357,8 +1387,10 @@ void mudclient_create_right_click_menu(mudclient *mud) {
 
     if (mud->selected_spell >= 0 &&
         game_data.spells[mud->selected_spell].type <= 1) {
-        sprintf(mud->menu_items[mud->menu_items_count].action_text, "Cast %s on self",
-                game_data.spells[mud->selected_spell].name);
+        snprintf(mud->menu_items[mud->menu_items_count].action_text,
+                 sizeof(mud->menu_items[mud->menu_items_count].action_text),
+                 "Cast %s on self",
+                 game_data.spells[mud->selected_spell].name);
 
         strcpy(mud->menu_items[mud->menu_items_count].target_text, "");
 
@@ -1376,7 +1408,8 @@ void mudclient_create_right_click_menu(mudclient *mud) {
     if (walkable) {
         if (mud->selected_spell >= 0) {
             if (game_data.spells[mud->selected_spell].type == 6) {
-                sprintf(mud->menu_items[mud->menu_items_count].action_text,
+                snprintf(mud->menu_items[mud->menu_items_count].action_text,
+                        sizeof(mud->menu_items[mud->menu_items_count].action_text),
                         "Cast %s on ground",
                         game_data.spells[mud->selected_spell].name);
 
@@ -1488,8 +1521,9 @@ void mudclient_draw_right_click_menu(mudclient *mud) {
         char *menu_item_text1 = mud->menu_items[mud->menu_indices[i]].action_text;
         char *menu_item_text2 = mud->menu_items[mud->menu_indices[i]].target_text;
 
-        char combined[strlen(menu_item_text1) + strlen(menu_item_text2) + 2];
-        sprintf(combined, "%s %s", menu_item_text1, menu_item_text2);
+        char combined[256];
+        snprintf(combined, sizeof(combined),
+            "%s %s", menu_item_text1, menu_item_text2);
 
         surface_draw_string(mud->surface, combined, entry_x, entry_y,
                             FONT_BOLD_12, text_colour);
@@ -1509,8 +1543,9 @@ void mudclient_draw_hover_tooltip(mudclient *mud) {
 
         char *menu_item_text2 = mud->menu_items[mud->menu_indices[0]].target_text;
 
-        char combined[strlen(menu_item_text1) + strlen(menu_item_text2) + 2];
-        sprintf(combined, "%s %s", menu_item_text1, menu_item_text2);
+        char combined[256];
+        snprintf(combined, sizeof(combined),
+            "%s %s", menu_item_text1, menu_item_text2);
 
         int text_width = surface_text_width(combined, FONT_BOLD_12);
         int text_height = surface_text_height(FONT_BOLD_12);

--- a/src/ui/menu.h
+++ b/src/ui/menu.h
@@ -67,8 +67,6 @@ typedef enum {
 #include "../mudclient.h"
 #include "transaction.h"
 
-#define MENU_ITEMS_MAX 300
-
 /* for mouse picking */
 #define PLAYER_FACE_TAG 10000
 #define GROUND_ITEM_FACE_TAG 20000

--- a/src/ui/menu.h
+++ b/src/ui/menu.h
@@ -67,7 +67,7 @@ typedef enum {
 #include "../mudclient.h"
 #include "transaction.h"
 
-#define MENU_ITEMS_MAX 20
+#define MENU_ITEMS_MAX 300
 
 /* for mouse picking */
 #define PLAYER_FACE_TAG 10000

--- a/src/ui/minimap-tab.c
+++ b/src/ui/minimap-tab.c
@@ -181,28 +181,28 @@ void mudclient_draw_ui_tab_minimap(mudclient *mud, int no_menus) {
 
     if (mud->options->compass_menu && mouse_x > 0 && mouse_x <= 32 &&
         mouse_y > 0 && mouse_y <= 32) {
-        strcpy(mud->menu_item_text1[mud->menu_items_count], "Look");
-        strcpy(mud->menu_item_text2[mud->menu_items_count], "North");
-        mud->menu_type[mud->menu_items_count] = MENU_MAP_LOOK;
-        mud->menu_index[mud->menu_items_count] = 128;
+        strcpy(mud->menu_items[mud->menu_items_count].action_text, "Look");
+        strcpy(mud->menu_items[mud->menu_items_count].target_text, "North");
+        mud->menu_items[mud->menu_items_count].type = MENU_MAP_LOOK;
+        mud->menu_items[mud->menu_items_count].index = 128;
         mud->menu_items_count++;
 
-        strcpy(mud->menu_item_text1[mud->menu_items_count], "Look");
-        strcpy(mud->menu_item_text2[mud->menu_items_count], "East");
-        mud->menu_type[mud->menu_items_count] = MENU_MAP_LOOK;
-        mud->menu_index[mud->menu_items_count] = 192;
+        strcpy(mud->menu_items[mud->menu_items_count].action_text, "Look");
+        strcpy(mud->menu_items[mud->menu_items_count].target_text, "East");
+        mud->menu_items[mud->menu_items_count].type = MENU_MAP_LOOK;
+        mud->menu_items[mud->menu_items_count].index = 192;
         mud->menu_items_count++;
 
-        strcpy(mud->menu_item_text1[mud->menu_items_count], "Look");
-        strcpy(mud->menu_item_text2[mud->menu_items_count], "South");
-        mud->menu_type[mud->menu_items_count] = MENU_MAP_LOOK;
-        mud->menu_index[mud->menu_items_count] = 0;
+        strcpy(mud->menu_items[mud->menu_items_count].action_text, "Look");
+        strcpy(mud->menu_items[mud->menu_items_count].target_text, "South");
+        mud->menu_items[mud->menu_items_count].type = MENU_MAP_LOOK;
+        mud->menu_items[mud->menu_items_count].index = 0;
         mud->menu_items_count++;
 
-        strcpy(mud->menu_item_text1[mud->menu_items_count], "Look");
-        strcpy(mud->menu_item_text2[mud->menu_items_count], "West");
-        mud->menu_type[mud->menu_items_count] = MENU_MAP_LOOK;
-        mud->menu_index[mud->menu_items_count] = 64;
+        strcpy(mud->menu_items[mud->menu_items_count].action_text, "Look");
+        strcpy(mud->menu_items[mud->menu_items_count].target_text, "West");
+        mud->menu_items[mud->menu_items_count].type = MENU_MAP_LOOK;
+        mud->menu_items[mud->menu_items_count].index = 64;
         mud->menu_items_count++;
         return;
     }

--- a/src/ui/offer-x.c
+++ b/src/ui/offer-x.c
@@ -64,11 +64,11 @@ void mudclient_handle_offer_x_input(mudclient *mud) {
 
 void mudclient_add_offer_menu(mudclient *mud, int type, int item_id, int amount,
                               char *display_amount, char *item_name) {
-    strcpy(mud->menu_item_text1[mud->menu_items_count], display_amount);
-    strcpy(mud->menu_item_text2[mud->menu_items_count], item_name);
-    mud->menu_type[mud->menu_items_count] = type;
-    mud->menu_index[mud->menu_items_count] = item_id;
-    mud->menu_target_index[mud->menu_items_count] = amount;
+    strcpy(mud->menu_items[mud->menu_items_count].action_text, display_amount);
+    strcpy(mud->menu_items[mud->menu_items_count].target_text, item_name);
+    mud->menu_items[mud->menu_items_count].type = type;
+    mud->menu_items[mud->menu_items_count].index = item_id;
+    mud->menu_items[mud->menu_items_count].target_index = amount;
     mud->menu_items_count++;
 }
 
@@ -122,9 +122,9 @@ void mudclient_add_offer_menus(mudclient *mud, char *type_string, int type,
                                  item_name);
     }
 
-    strcpy(mud->menu_item_text1[mud->menu_items_count], "Examine");
-    strcpy(mud->menu_item_text2[mud->menu_items_count], item_name);
-    mud->menu_type[mud->menu_items_count] = MENU_INVENTORY_EXAMINE;
-    mud->menu_index[mud->menu_items_count] = item_id;
+    strcpy(mud->menu_items[mud->menu_items_count].action_text, "Examine");
+    strcpy(mud->menu_items[mud->menu_items_count].target_text, item_name);
+    mud->menu_items[mud->menu_items_count].type = MENU_INVENTORY_EXAMINE;
+    mud->menu_items[mud->menu_items_count].index = item_id;
     mud->menu_items_count++;
 }

--- a/src/ui/transaction.c
+++ b/src/ui/transaction.c
@@ -405,23 +405,23 @@ void mudclient_draw_transaction(mudclient *mud, int dialog_x, int dialog_y,
                             item_amount, formatted_item_name,
                             mud->transaction_last_offer);
                     } else {
-                        strcpy(mud->menu_item_text1[mud->menu_items_count],
+                        strcpy(mud->menu_items[mud->menu_items_count].action_text,
                                "Examine");
 
-                        strcpy(mud->menu_item_text2[mud->menu_items_count],
+                        strcpy(mud->menu_items[mud->menu_items_count].target_text,
                                formatted_item_name);
 
-                        mud->menu_type[mud->menu_items_count] =
+                        mud->menu_items[mud->menu_items_count].type =
                             MENU_INVENTORY_EXAMINE;
 
-                        mud->menu_index[mud->menu_items_count] = item_id;
+                        mud->menu_items[mud->menu_items_count].index = item_id;
                         mud->menu_items_count++;
 
-                        strcpy(mud->menu_item_text1[mud->menu_items_count],
+                        strcpy(mud->menu_items[mud->menu_items_count].action_text,
                                "Cancel");
 
-                        strcpy(mud->menu_item_text2[mud->menu_items_count], "");
-                        mud->menu_type[mud->menu_items_count] = MENU_CANCEL;
+                        strcpy(mud->menu_items[mud->menu_items_count].target_text, "");
+                        mud->menu_items[mud->menu_items_count].type = MENU_CANCEL;
                         mud->menu_items_count++;
                     }
                 } else if (mud->mouse_item_count_increment > 0) {


### PR DESCRIPTION
Menus display more options when the screen is bigger, but the correct number of "more options" is always disabled (even in Catherby on RSC Uranium, where there can be thousands of fish dropped on the floor).

The size of large menus (those that exceed the maximum screen size) is properly calculated by stopping the starting position from being lower than zero.