### PR TITLE
Fix Offer-X after menus refactor

### DIFF
--- a/src/mudclient.h
+++ b/src/mudclient.h
@@ -481,9 +481,9 @@ struct MenuEntry {
     char wiki_page[64];
     /* data related to the target entity */
     int x, y;
-    uint16_t index;
-    uint16_t source_index;
-    uint16_t target_index;
+    int16_t index;
+    int16_t source_index;
+    int16_t target_index;
 };
 
 struct mudclient {


### PR DESCRIPTION
src/ui/offer-x.c does some magic with negative values to encode a value, which I was not expecting. Support negative menu "indices" in the struct.

Closes #171
Closes #170