### PR TITLE
mudclient: Make failing to open the audio device non-fatal.

### DIFF
--- a/src/mudclient.c
+++ b/src/mudclient.c
@@ -1008,7 +1008,6 @@ void mudclient_start_application(mudclient *mud, char *title) {
 
         if (SDL_OpenAudio(&wanted_audio, NULL) < 0) {
             mud_error("SDL_OpenAudio(): %s\n", SDL_GetError());
-            exit(1);
         }
     }
 #endif


### PR DESCRIPTION
Use case: Windows XP VM with no drivers installed.