### PR TITLE
Allow focus click passthrough

### DIFF
--- a/src/mudclient-sdl2.c
+++ b/src/mudclient-sdl2.c
@@ -233,6 +233,10 @@ void mudclient_start_application(mudclient *mud, char *title) {
         exit(1);
     }
 
+#ifdef SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH
+    SDL_SetHint(SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH, "1");
+#endif
+
 #ifdef __SWITCH__
     SDL_JoystickEventState(SDL_ENABLE);
     joystick = SDL_JoystickOpen(0);


### PR DESCRIPTION
Setting this [flag](https://wiki.libsdl.org/SDL2/SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH) allows for mouse clicks events to pass through when focusing an SDL window.

This seemed to work "on my machine" (macOS ARM), but I'm not sure if this is comprehensive as far as all build types, etc. Apologies if this is not the case, and hopefully the maintainers can see the idea through to completion if necessary.