### PR TITLE
Support runtime configuration of .jag/.mem versions

### DIFF
--- a/src/mudclient.c
+++ b/src/mudclient.c
@@ -926,30 +926,29 @@ int8_t *mudclient_read_data_file(mudclient *mud, char *file, char *description,
 #ifdef WII
     const int8_t *file_data = NULL;
 
-    if (strcmp(file, "jagex.jag") == 0) {
+    if (strstr(file, "jagex.jag") != NULL) {
         file_data = (int8_t *)jagex_jag;
-    } else if (strcmp(file, "config" VERSION_STR(VERSION_CONFIG) ".jag") == 0) {
+    } else if (strstr(file, "config") != NULL) {
         file_data = (int8_t *)config85_jag;
-    } else if (strcmp(file, "media" VERSION_STR(VERSION_MEDIA) ".jag") == 0) {
+    } else if (strstr(file, "media") != NULL) {
         file_data = (int8_t *)media58_jag;
-    } else if (strcmp(file, "entity" VERSION_STR(VERSION_ENTITY) ".jag") == 0) {
+    } else if (strstr(file, "entity") != NULL && strstr(file, ".mem") == NULL) {
         file_data = (int8_t *)entity24_jag;
-    } else if (strcmp(file, "entity" VERSION_STR(VERSION_ENTITY) ".mem") == 0) {
+    } else if (strstr(file, "entity") != NULL && strstr(file, ".mem") != NULL) {
         file_data = (int8_t *)entity24_mem;
-    } else if (strcmp(file, "textures" VERSION_STR(VERSION_TEXTURES) ".jag") ==
-               0) {
+    } else if (strstr(file, "textures") != NULL) {
         file_data = (int8_t *)textures17_jag;
-    } else if (strcmp(file, "maps" VERSION_STR(VERSION_MAPS) ".jag") == 0) {
+    } else if (strstr(file, "maps") != NULL && strstr(file, ".mem") == NULL) {
         file_data = (int8_t *)maps63_jag;
-    } else if (strcmp(file, "maps" VERSION_STR(VERSION_MAPS) ".mem") == 0) {
+    } else if (strstr(file, "maps") != NULL && strstr(file, ".mem") != NULL) {
         file_data = (int8_t *)maps63_mem;
-    } else if (strcmp(file, "land" VERSION_STR(VERSION_MAPS) ".jag") == 0) {
+    } else if (strstr(file, "land") != NULL && strstr(file, ".mem") == NULL) {
         file_data = (int8_t *)land63_jag;
-    } else if (strcmp(file, "land" VERSION_STR(VERSION_MAPS) ".mem") == 0) {
+    } else if (strstr(file, "land") != NULL && strstr(file, ".mem") != NULL) {
         file_data = (int8_t *)land63_mem;
-    } else if (strcmp(file, "models" VERSION_STR(VERSION_MODELS) ".jag") == 0) {
+    } else if (strstr(file, "models") != NULL) {
         file_data = (int8_t *)models36_jag;
-    } else if (strcmp(file, "sounds" VERSION_STR(VERSION_SOUNDS) ".mem") == 0) {
+    } else if (strstr(file, "sounds") != NULL) {
         file_data = (int8_t *)sounds1_mem;
     }
 
@@ -1110,8 +1109,12 @@ void mudclient_load_jagex(mudclient *mud) {
 }
 
 void mudclient_load_game_config(mudclient *mud) {
+    char jag[16];
+
+    snprintf(jag, sizeof(jag), "config%d.jag", mud->options->version_config);
+
     int8_t *config_jag = mudclient_read_data_file(
-        mud, "config" VERSION_STR(VERSION_CONFIG) ".jag", "Configuration", 10);
+        mud, jag, "Configuration", 10);
 
     if (config_jag == NULL) {
         mud->error_loading_data = 1;
@@ -1143,11 +1146,11 @@ void mudclient_load_game_config(mudclient *mud) {
 static void mudclient_load_media_dat(mudclient *mud, void *media_jag) {
     int8_t *index_dat = load_data("index.dat", 0, media_jag, NULL);
 
-#if (VERSION_MEDIA < 59)
-    surface_parse_sprite(mud->surface, mud->sprite_media,
-                         load_data("inv1.dat", 0, media_jag, NULL), index_dat,
-                         1);
-#endif
+    if (mud->options->version_media < 59) {
+        surface_parse_sprite(mud->surface, mud->sprite_media,
+                             load_data("inv1.dat", 0, media_jag, NULL),
+                             index_dat, 1);
+    }
 
     surface_parse_sprite(mud->surface, mud->sprite_media + 1,
                          load_data("inv2.dat", 0, media_jag, NULL), index_dat,
@@ -1189,23 +1192,23 @@ static void mudclient_load_media_dat(mudclient *mud, void *media_jag) {
                          load_data("buttons.dat", 0, media_jag, NULL),
                          index_dat, 2);
 
-#if (VERSION_MEDIA >= 59)
-    surface_parse_sprite(mud->surface, mud->sprite_media + 27,
-                         load_data("labels.dat", 0, media_jag, NULL), index_dat,
-                         6);
+    if (mud->options->version_media >= 59) {
+        surface_parse_sprite(mud->surface, mud->sprite_media + 27,
+                             load_data("labels.dat", 0, media_jag, NULL),
+                             index_dat, 6);
 
-    surface_parse_sprite(mud->surface, mud->sprite_media + 33,
-                         load_data("inv3.dat", 0, media_jag, NULL), index_dat,
-                         6);
+        surface_parse_sprite(mud->surface, mud->sprite_media + 33,
+                             load_data("inv3.dat", 0, media_jag, NULL),
+                             index_dat, 6);
 
-    surface_parse_sprite(mud->surface, mud->sprite_media + 39,
-                         load_data("message.dat", 0, media_jag, NULL),
-                         index_dat, 1);
+        surface_parse_sprite(mud->surface, mud->sprite_media + 39,
+                             load_data("message.dat", 0, media_jag, NULL),
+                             index_dat, 1);
 
-    surface_parse_sprite(mud->surface, mud->sprite_media + 40,
-                         load_data("keyboard.dat", 0, media_jag, NULL),
-                         index_dat, 1);
-#endif
+        surface_parse_sprite(mud->surface, mud->sprite_media + 40,
+                             load_data("keyboard.dat", 0, media_jag, NULL),
+                             index_dat, 1);
+    }
 
     surface_parse_sprite(mud->surface, mud->sprite_util,
                          load_data("scrollbar.dat", 0, media_jag, NULL),
@@ -1349,32 +1352,36 @@ static void mudclient_load_media_tga(mudclient *mud, void *media_jag) {
 
 void mudclient_load_media(mudclient *mud) {
 #if defined(RENDER_GL) || defined(RENDER_SW) || defined(RENDER_3DS_GL)
+    char jag[16];
+
+    snprintf(jag, sizeof(jag), "media%d.jag", mud->options->version_media);
+
     int8_t *media_jag = mudclient_read_data_file(
-        mud, "media" VERSION_STR(VERSION_MEDIA) ".jag", "2d graphics", 20);
+        mud, jag, "2d graphics", 20);
 
     if (media_jag == NULL) {
         mud->error_loading_data = 1;
         return;
     }
 
-#if !MEDIA_IS_TGA
-    mudclient_load_media_dat(mud, media_jag);
-#else
-    mudclient_load_media_tga(mud, media_jag);
-#endif
+    if (!MEDIA_IS_TGA(mud->options->version_media)) {
+        mudclient_load_media_dat(mud, media_jag);
+    } else {
+        mudclient_load_media_tga(mud, media_jag);
+    }
 
 #ifdef RENDER_SW
     /* this is probably for an optimization, but it is necessary for the action
      * bubble scaling */
-#if (VERSION_MEDIA >= 59)
-    for (int i = 0; i < 6; i++) {
-        surface_load_sprite(mud->surface, mud->sprite_media + 33 + i);
-    }
+    if (mud->options->version_media >= 59) {
+        for (int i = 0; i < 6; i++) {
+            surface_load_sprite(mud->surface, mud->sprite_media + 33 + i);
+        }
 
-    surface_load_sprite(mud->surface, mud->sprite_media + 39);
-#else
-    surface_load_sprite(mud->surface, mud->sprite_media);
-#endif
+        surface_load_sprite(mud->surface, mud->sprite_media + 39);
+    } else {
+        surface_load_sprite(mud->surface, mud->sprite_media);
+    }
 
     surface_load_sprite(mud->surface, mud->sprite_media + 9);
 
@@ -1399,9 +1406,11 @@ void mudclient_load_media(mudclient *mud) {
 
 void mudclient_load_entities(mudclient *mud) {
 #if defined(RENDER_GL) || defined(RENDER_SW) || defined(RENDER_3DS_GL)
+    char jag[16];
+    snprintf(jag, sizeof(jag), "entity%d.jag", mud->options->version_entity);
+
     int8_t *entity_jag = mudclient_read_data_file(
-        mud, "entity" VERSION_STR(VERSION_ENTITY) ".jag", "people and monsters",
-        30);
+        mud, jag, "people and monsters", 30);
 
     int8_t *entity_jag_legacy = NULL;
 
@@ -1410,7 +1419,7 @@ void mudclient_load_entities(mudclient *mud) {
         entity_jag_legacy = mudclient_read_data_file(mud, "entity8.jag",
                                                      "people and monsters", 37);
     }
-    if (ENTITY_IS_TGA) {
+    if (ENTITY_IS_TGA(mud->options->version_entity)) {
         entity_jag_legacy = entity_jag;
     }
 #endif
@@ -1424,10 +1433,12 @@ void mudclient_load_entities(mudclient *mud) {
     int8_t *entity_jag_mem = NULL;
     int8_t *index_dat_mem = NULL;
 
-    if (mud->options->members && !ENTITY_IS_TGA) {
+    if (mud->options->members && !ENTITY_IS_TGA(mud->options->version_entity)) {
+        snprintf(jag, sizeof(jag), "entity%d.mem",
+            mud->options->version_entity);
+
         entity_jag_mem = mudclient_read_data_file(
-            mud, "entity" VERSION_STR(VERSION_ENTITY) ".mem", "member graphics",
-            45);
+            mud, jag, "member graphics", 45);
 
         if (entity_jag_mem == NULL) {
             mud->error_loading_data = 1;
@@ -1461,7 +1472,7 @@ void mudclient_load_entities(mudclient *mud) {
         int8_t *archive_file = entity_jag;
 
 #if !defined(RENDER_GL) && !defined(RENDER_3DS_GL)
-        if (ENTITY_IS_TGA) {
+        if (ENTITY_IS_TGA(mud->options->version_entity)) {
             older_is_better = true;
             extension = "tga";
         } else if (mud->options->tga_sprites) {
@@ -1590,8 +1601,12 @@ fallthrough:
 
 void mudclient_load_textures(mudclient *mud) {
 #ifdef RENDER_SW
-    int8_t *textures_jag = mudclient_read_data_file(
-        mud, "textures" VERSION_STR(VERSION_TEXTURES) ".jag", "Textures", 50);
+    char jag[16];
+
+    snprintf(jag, sizeof(jag), "textures%d.jag",
+        mud->options->version_textures);
+
+    int8_t *textures_jag = mudclient_read_data_file(mud, jag, "Textures", 50);
 
     if (textures_jag == NULL) {
         mud->error_loading_data = 1;
@@ -1698,7 +1713,10 @@ void mudclient_load_models(mudclient *mud) {
         }
     }
 
-    char *models_filename = "models" VERSION_STR(VERSION_MODELS) ".jag";
+    char models_filename[16];
+
+    snprintf(models_filename, sizeof(models_filename),
+        "models%d.jag", mud->options->version_models);
 
     int8_t *models_jag =
         mudclient_read_data_file(mud, models_filename, "3d models", 60);
@@ -1828,29 +1846,38 @@ void mudclient_load_models(mudclient *mud) {
 }
 
 void mudclient_load_maps(mudclient *mud) {
+    char jag[16];
+
+    snprintf(jag, sizeof(jag), "maps%d.jag", mud->options->version_maps);
     mud->world->map_pack = mudclient_read_data_file(
-        mud, "maps" VERSION_STR(VERSION_MAPS) ".jag", "map", 70);
+        mud, jag, "map", 70);
 
     if (mud->options->members) {
+        snprintf(jag, sizeof(jag), "maps%d.mem", mud->options->version_maps);
         mud->world->member_map_pack = mudclient_read_data_file(
-            mud, "maps" VERSION_STR(VERSION_MAPS) ".mem", "members map", 75);
+            mud, jag, "members map", 75);
     }
 
-#if HAS_SEPARATE_LAND
-    mud->world->landscape_pack = mudclient_read_data_file(
-        mud, "land" VERSION_STR(VERSION_MAPS) ".jag", "landscape", 80);
+    if (HAS_SEPARATE_LAND(mud->options->version_maps)) {
+        snprintf(jag, sizeof(jag), "land%d.jag", mud->options->version_maps);
+        mud->world->landscape_pack = mudclient_read_data_file(
+            mud, jag, "landscape", 80);
 
-    if (mud->options->members) {
-        mud->world->member_landscape_pack = mudclient_read_data_file(
-            mud, "land" VERSION_STR(VERSION_MAPS) ".mem", "members landscape",
-            85);
+        if (mud->options->members) {
+            snprintf(jag, sizeof(jag), "land%d.mem",
+                mud->options->version_maps);
+            mud->world->member_landscape_pack = mudclient_read_data_file(
+                mud, jag, "members landscape", 85);
+        }
     }
-#endif
 }
 
 void mudclient_load_sounds(mudclient *mud) {
-    mud->sound_data = mudclient_read_data_file(
-        mud, "sounds" VERSION_STR(VERSION_SOUNDS) ".mem", "Sound effects", 90);
+    char jag[16];
+
+    snprintf(jag, sizeof(jag), "sounds%d.mem", mud->options->version_sounds);
+
+    mud->sound_data = mudclient_read_data_file(mud, jag, "Sound effects", 90);
 }
 
 void mudclient_reset_game(mudclient *mud) {

--- a/src/mudclient.c
+++ b/src/mudclient.c
@@ -2638,7 +2638,7 @@ void mudclient_start_game(mudclient *mud) {
 #endif
 
     mud->world = malloc(sizeof(World));
-    world_new(mud->world, mud->scene, mud->surface);
+    world_new(mud->world, mud->scene, mud->surface, mud->options->version_maps);
 
     /* used for storing minimap sprite */
     mud->world->base_media_sprite = mud->sprite_media;

--- a/src/options.c
+++ b/src/options.c
@@ -38,6 +38,13 @@ void options_new(Options *options) {
 void options_set_defaults(Options *options) {
     /* server */
     options->members = 1;
+    options->version_config = VERSION_CONFIG;
+    options->version_entity = VERSION_ENTITY;
+    options->version_maps = VERSION_MAPS;
+    options->version_media = VERSION_MEDIA;
+    options->version_models = VERSION_MODELS;
+    options->version_sounds = VERSION_SOUNDS;
+    options->version_textures = VERSION_TEXTURES;
     options->fatigue = 1;
     options->max_quests = 50;
     options->max_skills = 18;
@@ -121,6 +128,13 @@ void options_set_defaults(Options *options) {
 void options_set_vanilla(Options *options) {
     /* connection */
     options->members = 1;
+    options->version_config = VERSION_CONFIG;
+    options->version_entity = VERSION_ENTITY;
+    options->version_maps = VERSION_MAPS;
+    options->version_media = VERSION_MEDIA;
+    options->version_models = VERSION_MODELS;
+    options->version_sounds = VERSION_SOUNDS;
+    options->version_textures = VERSION_TEXTURES;
     options->fatigue = 1;
     options->max_quests = 50;
     options->max_skills = 18;
@@ -219,6 +233,13 @@ void options_save(Options *options) {
     sprintf(file_buffer, OPTIONS_INI_TEMPLATE,
             options->members,               //
             options->fatigue,               //
+            options->version_config,        //
+            options->version_maps,          //
+            options->version_entity,        //
+            options->version_media,         //
+            options->version_models,        //
+            options->version_textures,      //
+            options->version_sounds,        //
             options->last_world,            //
             options->max_quests,            //
             options->max_skills,            //
@@ -316,6 +337,13 @@ void options_load(Options *options) {
 
     /* connection */
     OPTION_INI_INT("members", options->members, 0, 1);
+    OPTION_INI_INT("version_config", options->version_config, 0, 256);
+    OPTION_INI_INT("version_maps", options->version_maps, 0, 256);
+    OPTION_INI_INT("version_entity", options->version_entity, 0, 256);
+    OPTION_INI_INT("version_media", options->version_media, 0, 256);
+    OPTION_INI_INT("version_models", options->version_models, 0, 256);
+    OPTION_INI_INT("version_textures", options->version_textures, 0, 256);
+    OPTION_INI_INT("version_sounds", options->version_sounds, 0, 256);
     OPTION_INI_INT("fatigue", options->fatigue, 0, 1);
     OPTION_INI_INT("last_world", options->last_world, 0, 256);
     OPTION_INI_INT("max_quests", options->max_quests, 0, 50);

--- a/src/options.h
+++ b/src/options.h
@@ -19,8 +19,16 @@ typedef struct Options Options;
      "members = %d\n"                                                          \
      "; Disables display of Fatigue, for servers that don't support it\n"      \
      "fatigue = %d\n"                                                          \
+     "; Versions of .jag and .mem files to load\n"                             \
+     "version_config = %d\n"                                                   \
+     "version_maps = %d\n"                                                     \
+     "version_entity = %d\n"                                                   \
+     "version_media = %d\n"                                                    \
+     "version_models = %d\n"                                                   \
+     "version_textures = %d\n"                                                 \
+     "version_sounds = %d\n"                                                   \
      "; Last selected entry on world list\n"                                   \
-     "last_world = %d\n"                                                        \
+     "last_world = %d\n"                                                       \
      "; Maximum number of quests to display (50 for final version of RSC)\n"   \
      "max_quests = %d\n"                                                       \
      "; Maximum number of skills to display (18 for final version of RSC)\n"   \
@@ -179,6 +187,14 @@ struct Options {
 
     /* disable display of fatigue */
     int fatigue;
+
+    int version_config;
+    int version_maps;
+    int version_entity;
+    int version_media;
+    int version_models;
+    int version_textures;
+    int version_sounds;
 
     /* last selected world on list */
     int last_world;

--- a/src/ui/additional-options.c
+++ b/src/ui/additional-options.c
@@ -136,15 +136,17 @@ void mudclient_create_options_panel(mudclient *mud) {
     x += (ADDITIONAL_OPTIONS_WIDTH - 4) / 2;
     y = ui_y + OPTION_HORIZ_GAP + ADDITIONAL_OPTIONS_TAB_HEIGHT + 4;
 
-#if VERSION_ENTITY > 8
-    control = mudclient_add_option_panel_checkbox(
-        mud->panel_game_options,
-        "@whi@HQ sprites (restart): ", mud->options->tga_sprites, x, y);
+#ifndef RENDER_GL
+    if (mud->options->version_entity > 8) {
+        control = mudclient_add_option_panel_checkbox(
+            mud->panel_game_options,
+            "@whi@HQ sprites (restart): ", mud->options->tga_sprites, x, y);
 
-    mud->game_options[control] = &mud->options->tga_sprites;
-    mud->game_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
+        mud->game_options[control] = &mud->options->tga_sprites;
+        mud->game_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += OPTION_HORIZ_GAP;
+        y += OPTION_HORIZ_GAP;
+    }
 #endif
 
     control = mudclient_add_option_panel_checkbox(
@@ -469,16 +471,16 @@ void mudclient_create_options_panel(mudclient *mud) {
 
     y += OPTION_HORIZ_GAP;
 
-#if VERSION_MEDIA > 42
-    control = mudclient_add_option_panel_checkbox(
-        mud->panel_ui_options, "@whi@Wiki lookup: ", mud->options->wiki_lookup,
-        x, y);
+    if (mud->options->version_media > 42) {
+        control = mudclient_add_option_panel_checkbox(
+            mud->panel_ui_options, "@whi@Wiki lookup: ",
+            mud->options->wiki_lookup, x, y);
 
-    mud->ui_options[control] = &mud->options->wiki_lookup;
-    mud->ui_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
+        mud->ui_options[control] = &mud->options->wiki_lookup;
+        mud->ui_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += OPTION_HORIZ_GAP;
-#endif
+        y += OPTION_HORIZ_GAP;
+    }
 
     control = mudclient_add_option_panel_checkbox(
         mud->panel_ui_options,

--- a/src/ui/additional-options.c
+++ b/src/ui/additional-options.c
@@ -435,14 +435,16 @@ void mudclient_create_options_panel(mudclient *mud) {
 
     y += OPTION_HORIZ_GAP;
 
-    control = mudclient_add_option_panel_checkbox(
-        mud->panel_ui_options,
-        "@whi@Certificate items: ", mud->options->certificate_items, x, y);
+    if (mud->options->version_media >= 59) {
+        control = mudclient_add_option_panel_checkbox(
+            mud->panel_ui_options,
+            "@whi@Certificate items: ", mud->options->certificate_items, x, y);
 
-    mud->ui_options[control] = &mud->options->certificate_items;
-    mud->ui_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
+        mud->ui_options[control] = &mud->options->certificate_items;
+        mud->ui_option_types[control] = ADDITIONAL_OPTIONS_CHECKBOX;
 
-    y += OPTION_HORIZ_GAP;
+        y += OPTION_HORIZ_GAP;
+    }
 
     control = mudclient_add_option_panel_checkbox(
         mud->panel_ui_options, "@whi@Status bars: ", mud->options->status_bars,

--- a/src/ui/inventory-tab.c
+++ b/src/ui/inventory-tab.c
@@ -24,10 +24,10 @@ void mudclient_draw_ui_tab_inventory(mudclient *mud, int no_menus) {
         ui_y = (UI_TABS_TOUCH_Y + UI_TABS_TOUCH_HEIGHT) - height - 2;
     }
 
-#if (VERSION_MEDIA >= 59)
-    mudclient_draw_ui_tab_label(mud, INVENTORY_TAB, width, ui_x,
-                                ui_y - UI_TABS_LABEL_HEIGHT);
-#endif
+    if (mud->options->version_media >= 59) {
+            mudclient_draw_ui_tab_label(mud, INVENTORY_TAB, width, ui_x,
+                                        ui_y - UI_TABS_LABEL_HEIGHT);
+    }
 
     mud->ui_tab_min_x = ui_x;
     mud->ui_tab_max_x = mud->surface->width;

--- a/src/ui/magic-tab.c
+++ b/src/ui/magic-tab.c
@@ -16,10 +16,11 @@ void mudclient_draw_ui_tab_magic(mudclient *mud, int no_menus) {
         ui_y = (UI_TABS_TOUCH_Y + UI_TABS_TOUCH_HEIGHT) - height - 2;
     }
 
-#if (VERSION_MEDIA >= 59)
-    mudclient_draw_ui_tab_label(mud, MAGIC_TAB, MAGIC_WIDTH + !is_touch,
-                                ui_x - !is_touch, ui_y - UI_TABS_LABEL_HEIGHT);
-#endif
+    if (mud->options->version_media >= 59) {
+        mudclient_draw_ui_tab_label(mud, MAGIC_TAB, MAGIC_WIDTH + !is_touch,
+                                    ui_x - !is_touch,
+                                    ui_y - UI_TABS_LABEL_HEIGHT);
+    }
 
     mud->ui_tab_min_x = ui_x;
     mud->ui_tab_max_x = mud->surface->width;

--- a/src/ui/message-tabs.c
+++ b/src/ui/message-tabs.c
@@ -179,7 +179,7 @@ void mudclient_draw_chat_message_tabs(mudclient *mud) {
         mud->surface, is_compact ? "Private" : "Private history",
         x + (button_width * 3) + 1, y, FONT_REGULAR_11, text_colour);
 
-    if (!is_compact && VERSION_MEDIA > 42) {
+    if (!is_compact && mud->options->version_media > 42) {
         surface_draw_string_centre(
             mud->surface,
             mud->options->wiki_lookup ? "Wiki lookup" : "Report abuse",

--- a/src/ui/minimap-tab.c
+++ b/src/ui/minimap-tab.c
@@ -37,10 +37,10 @@ void mudclient_draw_ui_tab_minimap(mudclient *mud, int no_menus) {
         mud->ui_tab_max_y = ui_y + MINIMAP_HEIGHT;
     }
 
-#if (VERSION_MEDIA >= 59)
-    mudclient_draw_ui_tab_label(mud, MAP_TAB, MINIMAP_WIDTH, ui_x,
-                                ui_y - UI_TABS_LABEL_HEIGHT);
-#endif
+    if (mud->options->version_media >= 59) {
+        mudclient_draw_ui_tab_label(mud, MAP_TAB, MINIMAP_WIDTH, ui_x,
+                                    ui_y - UI_TABS_LABEL_HEIGHT);
+    }
 
     surface_draw_box(mud->surface, ui_x, ui_y, MINIMAP_WIDTH, MINIMAP_HEIGHT,
                      BLACK);

--- a/src/ui/options-tab.c
+++ b/src/ui/options-tab.c
@@ -200,10 +200,11 @@ void mudclient_draw_ui_tab_options(mudclient *mud, int no_menus) {
         ui_y = (UI_TABS_TOUCH_Y + UI_TABS_TOUCH_HEIGHT) - height - 2;
     }
 
-#if (VERSION_MEDIA >= 59)
-    mudclient_draw_ui_tab_label(mud, OPTIONS_TAB, OPTIONS_WIDTH + !is_touch,
-                                ui_x - !is_touch, ui_y - UI_TABS_LABEL_HEIGHT);
-#endif
+    if (mud->options->version_media >= 59) {
+        mudclient_draw_ui_tab_label(mud, OPTIONS_TAB, OPTIONS_WIDTH + !is_touch,
+                                    ui_x - !is_touch,
+                                    ui_y - UI_TABS_LABEL_HEIGHT);
+    }
 
     mud->ui_tab_min_x = ui_x;
     mud->ui_tab_max_x = mud->surface->width;

--- a/src/ui/social-tab.c
+++ b/src/ui/social-tab.c
@@ -142,10 +142,12 @@ void mudclient_draw_ui_tab_social(mudclient *mud, int no_menus) {
         ui_y = (UI_TABS_TOUCH_Y + UI_TABS_TOUCH_HEIGHT) - height - 2;
     }
 
-#if (VERSION_MEDIA >= 59)
-    mudclient_draw_ui_tab_label(mud, SOCIAL_TAB, SOCIAL_WIDTH + !is_touch,
-                                ui_x - !is_touch, ui_y - UI_TABS_LABEL_HEIGHT);
-#endif
+    if (mud->options->version_media >= 59) {
+            mudclient_draw_ui_tab_label(mud, SOCIAL_TAB,
+                                        SOCIAL_WIDTH + !is_touch,
+                                        ui_x - !is_touch,
+                                        ui_y - UI_TABS_LABEL_HEIGHT);
+    }
 
     mud->ui_tab_min_x = ui_x;
     mud->ui_tab_max_x = mud->surface->width;

--- a/src/ui/stats-tab.c
+++ b/src/ui/stats-tab.c
@@ -176,10 +176,11 @@ void mudclient_draw_ui_tab_stats(mudclient *mud, int no_menus) {
     mud->panel_quests->control_height[mud->control_list_quest] =
         height - STATS_TAB_HEIGHT;
 
-#if (VERSION_MEDIA >= 59)
-    mudclient_draw_ui_tab_label(mud, STATS_TAB, STATS_WIDTH + !is_touch,
-                                ui_x - !is_touch, ui_y - UI_TABS_LABEL_HEIGHT);
-#endif
+    if (mud->options->version_media >= 59) {
+            mudclient_draw_ui_tab_label(mud, STATS_TAB, STATS_WIDTH + !is_touch,
+                                        ui_x - !is_touch,
+                                        ui_y - UI_TABS_LABEL_HEIGHT);
+    }
 
     mud->ui_tab_min_x = ui_x;
     mud->ui_tab_max_x = mud->surface->width;

--- a/src/ui/ui-tabs.c
+++ b/src/ui/ui-tabs.c
@@ -75,41 +75,41 @@ void mudclient_draw_ui_tabs(mudclient *mud) {
 
     int button_y = 3;
 
-#if (VERSION_MEDIA >= 59)
-    int button_x = mud->surface->width - UI_BUTTON_SIZE;
-
-    if (is_touch) {
-        button_x = UI_TABS_TOUCH_X;
-        button_y = UI_TABS_TOUCH_Y;
-    }
-
-    for (int i = 0; i < 6; i++) {
-        int selected_tab = i + 1;
-
-        if (is_touch && selected_tab == INVENTORY_TAB &&
-            mud->selected_item_inventory_index >= 0) {
-            mudclient_draw_inventory_icon(mud, button_x, button_y, 0);
-        } else if (is_touch && selected_tab == MAGIC_TAB &&
-                   mud->selected_spell >= 0) {
-            mudclient_draw_magic_icon(mud, button_x, button_y, 0);
-        } else {
-            surface_draw_sprite_alpha(mud->surface, button_x, button_y,
-                                      mud->sprite_media + 33 + i, 128);
-        }
+    if (mud->options->version_media >= 59) {
+        int button_x = mud->surface->width - UI_BUTTON_SIZE;
 
         if (is_touch) {
-            button_y += UI_BUTTON_SIZE - 2;
-        } else {
-            button_x -= UI_BUTTON_SIZE - 2;
+            button_x = UI_TABS_TOUCH_X;
+            button_y = UI_TABS_TOUCH_Y;
         }
-    }
-#else
-    int button_x =
-        mud->surface->width - mud->surface->sprite_width[mud->sprite_media] - 3;
 
-    surface_draw_sprite_alpha(mud->surface, button_x, button_y,
-                              mud->sprite_media, 128);
-#endif
+        for (int i = 0; i < 6; i++) {
+            int selected_tab = i + 1;
+
+            if (is_touch && selected_tab == INVENTORY_TAB &&
+                mud->selected_item_inventory_index >= 0) {
+                mudclient_draw_inventory_icon(mud, button_x, button_y, 0);
+            } else if (is_touch && selected_tab == MAGIC_TAB &&
+                       mud->selected_spell >= 0) {
+                mudclient_draw_magic_icon(mud, button_x, button_y, 0);
+            } else {
+                surface_draw_sprite_alpha(mud->surface, button_x, button_y,
+                                          mud->sprite_media + 33 + i, 128);
+            }
+
+            if (is_touch) {
+                button_y += UI_BUTTON_SIZE - 2;
+            } else {
+                button_x -= UI_BUTTON_SIZE - 2;
+            }
+        }
+    } else {
+        int button_x =
+            mud->surface->width - mud->surface->sprite_width[mud->sprite_media] - 3;
+
+        surface_draw_sprite_alpha(mud->surface, button_x, button_y,
+                                  mud->sprite_media, 128);
+    }
 
     mudclient_draw_inventory_count(mud);
 }
@@ -246,31 +246,33 @@ void mudclient_draw_active_ui_tab(mudclient *mud, int no_menus) {
 
     if (mud->show_ui_tab != 0) {
         int selected_y = 3;
+        int selected_x;
 
-#if (VERSION_MEDIA >= 59)
-        int selected_x = mud->surface->width -
+        if (mud->options->version_media >= 59) {
+            selected_x = mud->surface->width -
                          UI_BUTTON_SIZE * mud->show_ui_tab +
                          (mud->show_ui_tab - 1) * 2;
 
-        if (mudclient_is_touch(mud)) {
-            selected_x = UI_TABS_TOUCH_X;
+            if (mudclient_is_touch(mud)) {
+                selected_x = UI_TABS_TOUCH_X;
 
-            selected_y =
-                UI_TABS_TOUCH_Y + (mud->show_ui_tab - 1) * (UI_BUTTON_SIZE - 2);
+                selected_y = UI_TABS_TOUCH_Y +
+                    (mud->show_ui_tab - 1) * (UI_BUTTON_SIZE - 2);
 
-            if (mud->show_ui_tab == INVENTORY_TAB &&
-                mud->selected_item_inventory_index >= 0) {
-                mudclient_draw_inventory_icon(mud, selected_x, selected_y, 1);
-                return;
-            } else if (mud->show_ui_tab == MAGIC_TAB &&
-                       mud->selected_spell >= 0) {
-                mudclient_draw_magic_icon(mud, selected_x, selected_y, 1);
-                return;
+                if (mud->show_ui_tab == INVENTORY_TAB &&
+                    mud->selected_item_inventory_index >= 0) {
+                    mudclient_draw_inventory_icon(mud,
+                        selected_x, selected_y, 1);
+                    return;
+                } else if (mud->show_ui_tab == MAGIC_TAB &&
+                           mud->selected_spell >= 0) {
+                    mudclient_draw_magic_icon(mud, selected_x, selected_y, 1);
+                    return;
+                }
             }
+        } else {
+            selected_x = mud->surface->width - UI_TABS_WIDTH - 3;
         }
-#else
-        int selected_x = mud->surface->width - UI_TABS_WIDTH - 3;
-#endif
 
         surface_draw_sprite(mud->surface, selected_x, selected_y,
                             mud->sprite_media + mud->show_ui_tab);

--- a/src/version.h
+++ b/src/version.h
@@ -16,7 +16,4 @@
 
 #define HAS_SEPARATE_LAND(x) ((x) > 27)
 
-#define VERSION_STR_HELPER(x) #x
-#define VERSION_STR(x) VERSION_STR_HELPER(x)
-
 #endif

--- a/src/version.h
+++ b/src/version.h
@@ -11,10 +11,10 @@
 #define VERSION_SOUNDS 1
 #define VERSION_TEXTURES 17
 
-#define ENTITY_IS_TGA     (VERSION_ENTITY < 9)
-#define MEDIA_IS_TGA      (VERSION_MEDIA < 28)
+#define ENTITY_IS_TGA(x)     ((x) < 9)
+#define MEDIA_IS_TGA(x)      ((x) < 28)
 
-#define HAS_SEPARATE_LAND (VERSION_MAPS > 27)
+#define HAS_SEPARATE_LAND(x) ((x) > 27)
 
 #define VERSION_STR_HELPER(x) #x
 #define VERSION_STR(x) VERSION_STR_HELPER(x)

--- a/src/world.c
+++ b/src/world.c
@@ -46,12 +46,13 @@ void init_world_global(void) {
     }
 }
 
-void world_new(World *world, Scene *scene, Surface *surface) {
+void world_new(World *world, Scene *scene, Surface *surface, int version) {
     memset(world, 0, sizeof(World));
 
     world->scene = scene;
     world->surface = surface;
     world->player_alive = 0;
+    world->version = version;
 }
 
 static void world_set_blocked(World *world, int x, int y, int value) {
@@ -504,25 +505,25 @@ static void world_load_section_files(World *world, int x, int y, int plane,
         for (int tile = 0; tile < TILE_COUNT;) {
             int val = get_unsigned_byte(map_data, offset++, len);
 
-#if VERSION_MAPS > 53
-            world->walls_north_south[chunk][tile++] = val;
-#elif VERSION_MAPS > 45
-            if (val < 192) {
+            if (world->version > 53) {
                 world->walls_north_south[chunk][tile++] = val;
+            } else if (world->version > 45) {
+                if (val < 192) {
+                    world->walls_north_south[chunk][tile++] = val;
+                } else {
+                    for (int i = 0; i < val - 192; i++) {
+                        world->walls_north_south[chunk][tile++] = 0;
+                    }
+                }
             } else {
-                for (int i = 0; i < val - 192; i++) {
-                    world->walls_north_south[chunk][tile++] = 0;
+                if (val < 128) {
+                    world->walls_north_south[chunk][tile++] = val;
+                } else {
+                    for (int i = 0; i < val - 128; i++) {
+                        world->walls_north_south[chunk][tile++] = 0;
+                    }
                 }
             }
-#else
-            if (val < 128) {
-                world->walls_north_south[chunk][tile++] = val;
-            } else {
-                for (int i = 0; i < val - 128; i++) {
-                    world->walls_north_south[chunk][tile++] = 0;
-                }
-            }
-#endif
         }
 
         for (int tile = 0; tile < TILE_COUNT;) {

--- a/src/world.h
+++ b/src/world.h
@@ -68,6 +68,7 @@ struct World {
     Scene *scene;
     Surface *surface;
     int8_t player_alive;
+    int version;
     int base_media_sprite;
     int8_t *landscape_pack;
     int8_t *map_pack;
@@ -108,7 +109,7 @@ void world_gl_buffer_world_models(World *world);
 void world_gl_update_terrain_buffers(World *world);
 #endif
 
-void world_new(World *world, Scene *scene, Surface *surface);
+void world_new(World *world, Scene *scene, Surface *surface, int version);
 void world_load_section(World *world, int x, int y, int plane);
 int world_route(World *world, int start_x, int start_y, int end_x1, int end_y1,
                 int end_x2, int end_y2, int *route_x, int *route_y,


### PR DESCRIPTION
This is the first steps towards supporting OpenRSC and Sundae with the same binary. In the process, we remove a lot of `#ifdef`, making the code less ugly to read.