### PR TITLE
restore default rsa exp/mod (rscsundae compat)

### DIFF
--- a/src/ui/worldlist.c
+++ b/src/ui/worldlist.c
@@ -39,6 +39,12 @@ static void worldlist_set_defaults(void) {
     list[2].port = USE_WEBSOCKS ? 43494 : 43594;
     strcpy(list[2].rsa_exponent, "00010001");
     strcpy(list[2].rsa_modulus, "86b03ac30518bdb3e508ca9660efc7738a73ee7dbedbcebf8c56d030a2bdae70503c60829b7fb5eceb529442234c21bce6d529c8da4fce870e83ceffc379e281");
+
+    strcpy(list[3].name, "localhost");
+    strcpy(list[3].host, "localhost");
+    list[3].port = 43594;
+    strcpy(list[3].rsa_exponent, "81f390b2cf8ca7039ee507975951d5a0b15a87bf8b3f99c966834118c50fd94d");
+    strcpy(list[3].rsa_modulus, "88c38748a58228f7261cdc340b5691d7d0975dee0ecdb717609e6bf971eb3fe723ef9d130e4686813739768ad9472eb46d8bfcc042c1a5fcb05e931f632eea5d");
 }
 
 static void worldlist_read_presets(struct mudclient *mud) {

--- a/src/ui/worldlist.c
+++ b/src/ui/worldlist.c
@@ -42,7 +42,7 @@ static void worldlist_set_defaults(void) {
 
     strcpy(list[3].name, "localhost");
     strcpy(list[3].host, "localhost");
-    list[3].port = 43594;
+    list[3].port = USE_WEBSOCKS ? 43595 : 43594;
     strcpy(list[3].rsa_exponent, "81f390b2cf8ca7039ee507975951d5a0b15a87bf8b3f99c966834118c50fd94d");
     strcpy(list[3].rsa_modulus, "88c38748a58228f7261cdc340b5691d7d0975dee0ecdb717609e6bf971eb3fe723ef9d130e4686813739768ad9472eb46d8bfcc042c1a5fcb05e931f632eea5d");
 }


### PR DESCRIPTION
These are the same as the 225 rs2 client, so it's easier for people to run rscsundae locally.